### PR TITLE
Ignore this - test PR to see if Circle CI checks

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,2 +1,4 @@
+Test if CI triggers in PR
+
 {{main-map}}
 {{outlet}}


### PR DESCRIPTION
ESLint is part of the test suite and will fail if there are ESLint errors
