### PR TITLE
Disable space-before-function-paren, prefer-arrow-callback

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,5 +15,6 @@ module.exports = {
     'lines-around-directive': 0,
     'func-names': 0,
     'space-before-function-paren': 0,
+    'prefer-arrow-callback': 0,
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
     'import/extensions': 0,
     'lines-around-directive': 0,
     'func-names': 0,
+    'space-before-function-paren': 0,
   }
 };


### PR DESCRIPTION
@chriswhong I'd like to remove this out of convenience and personal taste, which was influenced mostly by Mike Bostock D3 examples.