### PR TITLE
fix partial lot highlighting

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -181,15 +181,15 @@ export default Ember.Component.extend({
 
   zoom: 10.2,
 
-  highlightedLotFeature: null,
+  highlightedLotFeatures: [],
 
-  @computed('highlightedLotFeature')
-  highlightedLotSource(feature) {
+  @computed('highlightedLotFeatures')
+  highlightedLotSource(features) {
     return {
       type: 'geojson',
       data: {
         type: 'FeatureCollection',
-        features: [feature],
+        features,
       },
     };
   },
@@ -240,19 +240,22 @@ export default Ember.Component.extend({
     },
 
     handleMouseover(e) {
-      const [feature] = e.target.queryRenderedFeatures(e.point, { layers: ['pluto-fill'] });
+      const features = e.target.queryRenderedFeatures(e.point, { layers: ['pluto-fill'] });
 
-      if (feature) {
-        const { bbl } = feature.properties;
+      if (features.length > 0) {
+        const { bbl } = features[0].properties;
 
         e.target.getCanvas().style.cursor = 'pointer';
 
-        const prevFeature = this.get('highlightedLotFeature');
-        if (!prevFeature || prevFeature.properties.bbl !== bbl) {
-          this.set('highlightedLotFeature', feature);
+        const prevFeatures = this.get('highlightedLotFeatures');
+
+        if (prevFeatures.length < 1 || prevFeatures[0].properties.bbl !== bbl) {
+          this.set('highlightedLotFeatures', features);
         }
       } else {
         e.target.getCanvas().style.cursor = '';
+
+        this.set('highlightedLotFeatures', []);
         this.set('mouseoverLocation', null);
       }
     },

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -19,7 +19,7 @@
     {{source.layer layer=plutoLineLayer }}
   {{/map.source}}
 
-  {{#if highlightedLotFeature}}
+  {{#if highlightedLotFeatures}}
     {{#map.source sourceId='highlighted-lot' options=highlightedLotSource as |source|}}
       {{source.layer layer=highlightedLotLayer before='waterway-label'}}
     {{/map.source}}

--- a/app/utils/search-pluto-lots.js
+++ b/app/utils/search-pluto-lots.js
@@ -2,15 +2,15 @@ import carto from '../utils/carto';
 
 export default function searchPlutoLots(text) {
   const SQL = `
-    SELECT (address || ', ' || 
-      CASE 
-        WHEN borough = 'MN' THEN 'Manhattan' 
-        WHEN borough = 'BX' THEN 'Bronx' 
-        WHEN borough = 'BK' THEN 'Brooklyn' 
-        WHEN borough = 'QN' THEN 'Queens' 
+    SELECT (address || ', ' ||
+      CASE
+        WHEN borough = 'MN' THEN 'Manhattan'
+        WHEN borough = 'BX' THEN 'Bronx'
+        WHEN borough = 'BK' THEN 'Brooklyn'
+        WHEN borough = 'QN' THEN 'Queens'
         WHEN borough = 'SI' THEN 'Staten Island'
-      END) as address, bbl FROM support_mappluto 
+      END) as address, bbl FROM support_mappluto
      WHERE address LIKE '%25${text.toUpperCase()}%25' LIMIT 10`;
 
   return carto.SQL(SQL);
-};
+}

--- a/tests/unit/utils/search-pluto-lots-test.js
+++ b/tests/unit/utils/search-pluto-lots-test.js
@@ -5,6 +5,6 @@ module('Unit | Utility | search pluto lots');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  let result = searchPlutoLots();
+  let result = searchPlutoLots('120 broadway');
   assert.ok(result);
 });


### PR DESCRIPTION
This PR fixes an issue where lots that are highlighted on mouseover would only partially render due to proximity to a tile edge.  

Instead of only taking the [0]th feature when using `queryrenderedfeatures`, all matching features are added to the map source for highlighting (the only situation where queryrenderedfeatures should return more than one feature is in this tile edge scenario)

Additionally, this PR also "unhighlights" the last highlighted lot when the user mouses out of the lots layer.