### PR TITLE
50 add zma route

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -82,12 +82,16 @@ export default Ember.Component.extend({
     },
 
     handleMouseover(e) {
-      const features = e.target.queryRenderedFeatures(e.point, { layers: ['pluto-fill'] });
+      const map = e.target;
+
+      const layers = ['pluto-fill', 'zma-fill'].filter(layer => map.getLayer(layer));
+
+      const features = map.queryRenderedFeatures(e.point, { layers });
 
       if (features.length > 0) {
         const { bbl } = features[0].properties;
 
-        e.target.getCanvas().style.cursor = 'pointer';
+        map.getCanvas().style.cursor = 'pointer';
 
         const prevFeatures = this.get('highlightedLotFeatures');
 
@@ -95,7 +99,7 @@ export default Ember.Component.extend({
           this.set('highlightedLotFeatures', features);
         }
       } else {
-        e.target.getCanvas().style.cursor = '';
+        map.getCanvas().style.cursor = '';
 
         this.set('highlightedLotFeatures', []);
         this.set('mouseoverLocation', null);

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -50,12 +50,19 @@ export default Ember.Controller.extend(mapQueryParams.Mixin, {
       this.transitionToRoute(...args);
     },
     routeToLot(e) {
-      const feature = e.target.queryRenderedFeatures(e.point, { layers: ['pluto-fill'] })[0];
-      const { bbl } = feature.properties;
+      const map = e.target;
+      // only query layers that are available in the map
+      const layers = ['pluto-fill', 'zma-fill'].filter(layer => map.getLayer(layer));
+      const feature = map.queryRenderedFeatures(e.point, { layers })[0];
+      const { bbl, ulurpno } = feature.properties;
 
       if (bbl) {
         const { boro, block, lot } = bblDemux(bbl);
         this.transitionToRoute('lot', boro, block, lot);
+      }
+
+      if (ulurpno) {
+        this.transitionToRoute('zma', ulurpno);
       }
     },
     setQueryParam(property, value) {

--- a/app/layer-groups/zoning-map-amendments.js
+++ b/app/layer-groups/zoning-map-amendments.js
@@ -7,13 +7,30 @@ export default {
   layers: [
     {
       layer: {
-        id: 'zma',
+        id: 'zma-fill',
+        type: 'fill',
+        source: 'zoning-map-amendments',
+        'source-layer': 'layer0',
+        paint: {
+          'fill-color': 'lightblue',
+          'fill-opacity': 0.2,
+        },
+      },
+    },
+    {
+      layer: {
+        id: 'zma-line',
         type: 'line',
         source: 'zoning-map-amendments',
         'source-layer': 'layer0',
         paint: {
-          'line-width': 2,
-          'line-color': 'red',
+          'line-width': {
+            stops: [
+              [11, 1],
+              [12, 3],
+            ],
+          },
+          'line-color': 'blue',
           'line-dasharray': [1, 1],
           'line-opacity': 0.6,
         },

--- a/app/layers/selected-lot.js
+++ b/app/layers/selected-lot.js
@@ -3,7 +3,7 @@ export default {
   type: 'fill',
   source: 'selected-lot',
   paint: {
-    'fill-opacity': 1,
+    'fill-opacity': 0.6,
     'fill-color': 'steelblue',
   },
 };

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -25,6 +25,11 @@ h6,
 .content-subheader {
 }
 
+.header-type {
+  color: $dark-gray;
+  font-weight:600;
+}
+
 //
 // Typograhpy helper classes
 // --------------------------------------------------

--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -1,3 +1,4 @@
+<label class="header-type">TAX LOT</label>
 {{#if model.landmark}}
   <h1 class="header-large content-header">{{model.landmark}}</h1>
   <h2 class="header-small content-subheader">{{model.address}}</h2>

--- a/app/templates/zma.hbs
+++ b/app/templates/zma.hbs
@@ -1,4 +1,5 @@
 
+<label class="header-type">ZONING MAP AMENDMENT</label>
 <h1 class="header-large">{{model.project_na}}</h1>
 
 <div class="data-grid">


### PR DESCRIPTION
This PR makes zma polygons clickable on the map, rerouting to zma
Also adds a type header on the content panes, so Tax Lots and Zoning Map Amendments can be easily differentiated.

Closes #50