### PR TITLE
Make date ranges inclusive of entire month

### DIFF
--- a/app/components/layer-control-timeline.js
+++ b/app/components/layer-control-timeline.js
@@ -42,7 +42,14 @@ export default Ember.Component.extend(ChildMixin, QueryParamMap, {
 
   actions: {
     sliderChanged(value) {
-      const range = value.map(epoch => fromEpoch(epoch));
+      const range = value
+        .map(epoch => fromEpoch(epoch))
+        .map((date, i) => { // eslint-disable-line
+          if (i === 0) {
+            return moment(date).startOf('month').format(defaultFormat);
+          }
+          return moment(date).endOf('month').format(defaultFormat);
+        });
       const column = this.get('column');
 
       this.set('start', value);


### PR DESCRIPTION
Adds some moment.js handlers to make the date range slider inclusive of whatever months are selected.  (Before it showed months, but the values passed to the SQL query were  day-specific)

Closes #101