### PR TITLE
new search layout

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -32,8 +32,6 @@
 
   @include breakpoint(large) {
     height: 100%;
-    padding-top: 3.375rem;
-    margin-top: -3.375rem;
     overflow: hidden;
   }
 }
@@ -46,11 +44,12 @@
 
   @include breakpoint(medium) {
     height: 100%;
-    width: calc(100% - 12rem);
+    width: calc(100% - 13rem);
   }
 
   @include breakpoint(large) {
     order: 2;
+    width: calc(100% - 15rem);
   }
 
   @include breakpoint(xlarge) {
@@ -58,6 +57,7 @@
   }
 }
 
+// .search-and-layers {
 .layer-palette {
   @include xy-cell-static(full,false,0);
   position: relative;
@@ -66,12 +66,14 @@
 
   @include breakpoint(medium) {
     @include xy-cell-block($vertical:true);
-    width: 12rem;
+    width: 13rem;
     box-shadow: -2px 0 0 rgba(0,0,0,0.1);
   }
 
   @include breakpoint(large) {
+    margin-top: 3.375rem;
     order: 1;
+    width: 15rem;
     box-shadow: 2px 0 0 rgba(0,0,0,0.1);
   }
 

--- a/app/styles/modules/_m-search.scss
+++ b/app/styles/modules/_m-search.scss
@@ -10,7 +10,15 @@
   z-index: 2;
 
   @include breakpoint(large) {
-    padding-right: rem-calc(38);
+    position: fixed;
+    top: 6rem;
+    left: 0;
+    width: 15rem;
+    box-shadow: 0 2px 0 rgba(0,0,0,0.1), 2px 0 0 rgba(0,0,0,0.1);
+  }
+
+  @include breakpoint(xlarge) {
+    width: 17.5rem;
   }
 
   input {
@@ -19,9 +27,14 @@
 
   .close-button {
     margin-top: rem-calc(2);
-    @include breakpoint(large) {
-      right: rem-calc(48);
-    }
+  }
+
+  .search-icon {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    color: $medium-gray;
+    pointer-events: none;
   }
 }
 
@@ -39,7 +52,10 @@
   transition: opacity 0.3s;
 
   @include breakpoint(large) {
-    max-width: 400px;
+    width: auto;
+    right: -4rem;
+    box-shadow: 4px 4px 0 rgba(0,0,0,0.1);
+    padding: 0 rem-calc(6) rem-calc(6);
   }
 
   &.has-results {
@@ -49,10 +65,16 @@
   .results-header {
     margin: rem-calc(10) 0 0;
   }
+  li:first-child .results-header {
+    margin-top: 0;
+  }
 
   li {
-    border-top: 1px solid $medium-gray;
     padding: $global-margin/2;
+  }
+
+  li:not(:first-child) {
+    border-top: 1px solid $medium-gray;
   }
 
   .result {
@@ -96,6 +118,10 @@
   box-shadow: 0 2px 0 rgba(0,0,0,0.1);
 
   @include breakpoint(large) {
-    max-width: 400px;
+    border-top: 0;
+    width: auto;
+    padding: rem-calc(6);
+    color: $body-font-color;
+    font-weight: $global-weight-bold;
   }
 }

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -33,11 +33,11 @@
     {{layer-menu-item for='pluto'}}
 
     {{#layer-menu-item
-      for='co' 
+      for='co'
       as |item|}}
       {{#if item.layer.visible}}
         {{#layer-multi-select-control
-          column='overlay' 
+          column='overlay'
           parentComponent=item.layer
           as |multiSelect|}}
             <ul class="layer-menu-item-controls">
@@ -89,7 +89,7 @@
             </ul>
         {{/layer-multi-select-control}}
       {{/if}}
-    {{/layer-menu-item}} 
+    {{/layer-menu-item}}
 
     {{#layer-menu-item for='zma' as |item|}}
       {{#if item.layer.visible}}

--- a/app/templates/components/map-search.hbs
+++ b/app/templates/components/map-search.hbs
@@ -3,6 +3,8 @@
   <button class="close-button" aria-label="Clear Search" type="button" {{action 'clear'}}>
     <span aria-hidden="true">&times;</span>
   </button>
+{{else}}
+  <span class="search-icon">{{fa-icon "search"}}</span>
 {{/if}}
 
 


### PR DESCRIPTION
This PR revises the search layout. 

It's currently ridiculously wide: 

![image](https://user-images.githubusercontent.com/409279/30755816-14aa659e-9f96-11e7-881c-da2a40b3c291.png)

Now that the layer palette is wider, it can match that width: 

<img src="https://user-images.githubusercontent.com/409279/30755757-e523e61a-9f95-11e7-9a08-d902c19570d8.png" width=300 />

I've also added a search icon when there are no terms: 

<img src="https://user-images.githubusercontent.com/409279/30755875-42394caa-9f96-11e7-965e-67a61e0433aa.png" width=250 />

