### PR TITLE
Add fixed layer order

### DIFF
--- a/app/components/layer-group.js
+++ b/app/components/layer-group.js
@@ -69,7 +69,7 @@ export default Ember.Component.extend(ParentMixin, ChildMixin, {
     const position = allLayerGroups.map(layerGroup => layerGroup.config.id).indexOf(this.get('config.id'));
 
     // walk all layergroups that should be displayed above this one
-    for (let i = position + 1; i < allLayerGroups.length; i += 1) {
+    for (let i = position - 1; i > 0; i -= 1) {
       const config = allLayerGroups[i].config;
       const bottomLayer = config.layers[0].layer.id;
       const map = this.get('mainMap.mapInstance');

--- a/app/components/layer-group.js
+++ b/app/components/layer-group.js
@@ -6,6 +6,8 @@ import carto from '../utils/carto';
 
 const { copy, merge, set } = Ember;
 
+const { service } = Ember.inject;
+
 const { alias } = Ember.computed;
 const { warn } = Ember.Logger;
 
@@ -24,6 +26,9 @@ export default Ember.Component.extend(ParentMixin, ChildMixin, {
       sql,
     });
   },
+
+  registeredLayers: service(),
+  mainMap: service(),
 
   tagName: '',
   qps: null,
@@ -56,6 +61,27 @@ export default Ember.Component.extend(ParentMixin, ChildMixin, {
   @computed('config.type')
   isCarto(type) {
     return type === 'carto';
+  },
+
+  @computed('registeredLayers.visibleLayerIds')
+  before() {
+    const allLayerGroups = this.get('registeredLayers.layers');
+    const position = allLayerGroups.map(layerGroup => layerGroup.config.id).indexOf(this.get('config.id'));
+
+    // walk all layergroups that should be displayed above this one
+    for (let i = position + 1; i < allLayerGroups.length; i += 1) {
+      const config = allLayerGroups[i].config;
+      const bottomLayer = config.layers[0].layer.id;
+      const map = this.get('mainMap.mapInstance');
+
+      // if the bottom-most layer of the layergroup exists on the map, use it as the 'before'
+      if (map.getLayer(bottomLayer)) {
+        return bottomLayer;
+      }
+    }
+
+    // if we can't find any before when walking the layergroups, use this 'global before'
+    return 'waterway-label';
   },
 
   layers: alias('config.layers'),

--- a/app/layer-groups/aerials16.js
+++ b/app/layer-groups/aerials16.js
@@ -8,7 +8,7 @@ export default {
   layers: [
     {
       layer: {
-        id: 'landuse-raster',
+        id: 'aerials16-raster',
         type: 'raster',
       },
       before: 'zd',

--- a/app/layer-groups/zd.js
+++ b/app/layer-groups/zd.js
@@ -2,6 +2,7 @@ export default {
   id: 'zd',
   title: 'Zoning Districts',
   sql: ['SELECT * FROM (SELECT *, LEFT(zonedist, 2) as primaryzone FROM support_zoning_zd) a'],
+  visible: true,
   type: 'carto',
   layers: [
     {

--- a/app/templates/components/layer-group.hbs
+++ b/app/templates/components/layer-group.hbs
@@ -5,16 +5,18 @@
     {{#each config.layers as |layerConfig|}}
       {{source.layer
         layer=layerConfig.layer
-        didUpdateLayers=didUpdateLayers}}
+        didUpdateLayers=didUpdateLayers
+        before=before
+      }}
     {{/each}}
   {{/map.source}}
 {{/if}}
 
-{{yield 
-  (hash 
+{{yield
+  (hash
     timeline-control=
       (component 'layer-control-timeline' layer=
-        (hash 
+        (hash
           visible=visible
         )
         qps=qps
@@ -22,7 +24,7 @@
 
     multi-select-control=
       (component 'layer-multi-select-control' layer=
-        (hash 
+        (hash
           visible=visible
         )
         qps=qps

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -13,13 +13,12 @@
   mapLoaded=(action 'handleMapLoad')
   as |map|}}
 
+
+
+
   {{map.layer-group config=layerGroups.aerials16 visible=qps.aerials16}}
 
   {{map.layer-group config=layerGroups.zd visible=qps.zd}}
-
-  {{map.layer-group config=layerGroups.pluto visible=qps.pluto}}
-
-  {{map.layer-group config=layerGroups.co visible=qps.co}}
 
   {{map.layer-group config=layerGroups.zma visible=qps.zma}}
 
@@ -50,6 +49,10 @@
   {{map.layer-group config=layerGroups.historicdistricts visible=qps.historicdistricts}}
 
   {{map.layer-group config=layerGroups.landmarkpoints visible=qps.landmarkpoints}}
+
+  {{map.layer-group config=layerGroups.co visible=qps.co}}
+
+  {{map.layer-group config=layerGroups.pluto visible=qps.pluto}}
 
   {{map.layer-group config=layerGroups.subway visible=qps.subway}}
 
@@ -84,9 +87,9 @@
       {{source.layer
         layer=selectedFillLayer
         before='waterway-label'}}
-        {{source.layer
-          layer=selectedLineLayer
-          before='waterway-label'}}
+      {{source.layer
+        layer=selectedLineLayer
+        before='waterway-label'}}
     {{/map.source}}
   {{/if}}
 

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -16,57 +16,57 @@
 
 
 
-  {{map.layer-group config=layerGroups.aerials16 visible=qps.aerials16}}
-
-  {{map.layer-group config=layerGroups.zd visible=qps.zd}}
-
-  {{map.layer-group config=layerGroups.zma visible=qps.zma}}
-
-  {{map.layer-group config=layerGroups.zmacert visible=qps.zmacert}}
-
-  {{map.layer-group config=layerGroups.sp visible=qps.sp}}
-
-  {{map.layer-group config=layerGroups.spsd visible=qps.spsd}}
-
-  {{map.layer-group config=layerGroups.mih visible=qps.mih}}
-
-  {{map.layer-group config=layerGroups.ih visible=qps.ih}}
-
-  {{map.layer-group config=layerGroups.tz visible=qps.tz}}
-
-  {{map.layer-group config=layerGroups.fresh visible=qps.fresh}}
-
-  {{map.layer-group config=layerGroups.sidewalkcafes visible=qps.sidewalkcafes}}
-
-  {{map.layer-group config=layerGroups.ldgma visible=qps.ldgma}}
-
-  {{map.layer-group config=layerGroups.czb visible=qps.czb}}
-
-  {{map.layer-group config=layerGroups.wap visible=qps.wap}}
-
-  {{map.layer-group config=layerGroups.sceniclandmarks visible=qps.sceniclandmarks}}
-
-  {{map.layer-group config=layerGroups.historicdistricts visible=qps.historicdistricts}}
-
-  {{map.layer-group config=layerGroups.landmarkpoints visible=qps.landmarkpoints}}
-
-  {{map.layer-group config=layerGroups.co visible=qps.co}}
-
-  {{map.layer-group config=layerGroups.pluto visible=qps.pluto}}
-
-  {{map.layer-group config=layerGroups.subway visible=qps.subway}}
-
-  {{map.layer-group config=layerGroups.boroughs visible=qps.boroughs}}
-
-  {{map.layer-group config=layerGroups.communitydistricts visible=qps.communitydistricts}}
-
-  {{map.layer-group config=layerGroups.nyccouncildistricts visible=qps.nyccouncildistricts}}
-
-  {{map.layer-group config=layerGroups.nysenatedistricts visible=qps.nysenatedistricts}}
+    {{map.layer-group config=layerGroups.nta visible=qps.nta}}
 
   {{map.layer-group config=layerGroups.assemblydistricts visible=qps.assemblydistricts}}
 
-  {{map.layer-group config=layerGroups.nta visible=qps.nta}}
+  {{map.layer-group config=layerGroups.nysenatedistricts visible=qps.nysenatedistricts}}
+
+  {{map.layer-group config=layerGroups.nyccouncildistricts visible=qps.nyccouncildistricts}}
+
+  {{map.layer-group config=layerGroups.communitydistricts visible=qps.communitydistricts}}
+
+  {{map.layer-group config=layerGroups.boroughs visible=qps.boroughs}}
+
+  {{map.layer-group config=layerGroups.subway visible=qps.subway}}
+
+  {{map.layer-group config=layerGroups.pluto visible=qps.pluto}}
+
+  {{map.layer-group config=layerGroups.co visible=qps.co}}
+
+  {{map.layer-group config=layerGroups.landmarkpoints visible=qps.landmarkpoints}}
+
+  {{map.layer-group config=layerGroups.historicdistricts visible=qps.historicdistricts}}
+
+  {{map.layer-group config=layerGroups.sceniclandmarks visible=qps.sceniclandmarks}}
+
+  {{map.layer-group config=layerGroups.wap visible=qps.wap}}
+
+  {{map.layer-group config=layerGroups.czb visible=qps.czb}}
+
+  {{map.layer-group config=layerGroups.ldgma visible=qps.ldgma}}
+
+  {{map.layer-group config=layerGroups.sidewalkcafes visible=qps.sidewalkcafes}}
+
+  {{map.layer-group config=layerGroups.fresh visible=qps.fresh}}
+
+  {{map.layer-group config=layerGroups.tz visible=qps.tz}}
+
+  {{map.layer-group config=layerGroups.ih visible=qps.ih}}
+
+  {{map.layer-group config=layerGroups.mih visible=qps.mih}}
+
+  {{map.layer-group config=layerGroups.spsd visible=qps.spsd}}
+
+  {{map.layer-group config=layerGroups.sp visible=qps.sp}}
+
+  {{map.layer-group config=layerGroups.zmacert visible=qps.zmacert}}
+
+  {{map.layer-group config=layerGroups.zma visible=qps.zma}}
+
+  {{map.layer-group config=layerGroups.zd visible=qps.zd}}
+
+  {{map.layer-group config=layerGroups.aerials16 visible=qps.aerials16}}
 
   {{#if mapMouseover.highlightedLotFeatures}}
     {{#map.source


### PR DESCRIPTION
This PR adds a fixed order to the layergroups in the app, allowing for toggling layergroups on and off and ensuring that they end up in the same place relative to other layergroups.

Layer order is defined by the order that layergroups are listed in `main-map.hbs`.  (The first layergroup in the template will be the top-most on the map, with the aerial rasters being last)

To accomplish this, we added a computed `before` property in `layer-group.js` which walks through all of the layergroups that are higher than the one being rendered.  If the layergroup's bottom-most layer exists in the map style, it uses that layer as the `before` property.  If not, it tried the next highest layergroup.  

If none of the higher layergroups has any layers on the map, it will default to using `waterway-label` as the `before` value.

*Things to consider*
- Highlighted and Selected layers are not rendered using `layer-group`, so they live outside of this framework.  Right now they are rendered `before` label-waterway, and after all of the other layergroups, so they will always render "on top"

- However, I think it would be a better-looking solution to make a highlight layer take the same position as the layer it is highlighting.  We might be able to use `moveLayer()` (which takes a `before` argument just like `addLayer()`) whenever the highlight feature is updated.
