### PR TITLE
add dtm raster layer

### DIFF
--- a/app/layer-groups/digital-tax-map.js
+++ b/app/layer-groups/digital-tax-map.js
@@ -1,0 +1,18 @@
+export default {
+  id: 'digital-tax-map',
+  type: 'raster',
+  title: 'Digital Tax Map',
+  tiles: ['https://zola-search-api.planninglabs.nyc/tiles/dtm/{z}/{x}/{y}.png'],
+  tileSize: 256,
+  visible: false,
+  minzoom: 15,
+  layers: [
+    {
+      layer: {
+        id: 'digitalTaxMa-raster',
+        type: 'raster',
+        minzoom: 15,
+      },
+    },
+  ],
+};

--- a/app/layer-groups/index.js
+++ b/app/layer-groups/index.js
@@ -4,6 +4,7 @@ import boroughs from './boroughs';
 import commercialOverlays from './commercial-overlays';
 import communitydistricts from './communitydistricts';
 import coastalZoneBoundary from './coastal-zone-boundary';
+import digitalTaxMap from './digital-tax-map';
 import facilities from './facilities';
 import fresh from './fresh';
 import historicdistricts from './historicdistricts';
@@ -33,6 +34,7 @@ export default {
   commercialOverlays,
   communitydistricts,
   coastalZoneBoundary,
+  digitalTaxMap,
   facilities,
   fresh,
   historicdistricts,

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -197,6 +197,8 @@
     closed=true
     title='Basemaps'}}
     {{layer-menu-item
+      for='digital-tax-map'}}
+    {{layer-menu-item
       for='aerials16'}}
   {{/layer-palette-accordion}}
 </div>

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -66,6 +66,8 @@
 
   {{map.layer-group for='zoning-districts' visible=qps.zoning-districts}}
 
+  {{map.layer-group for='digital-tax-map' visible=qps.digital-tax-map}}
+
   {{map.layer-group for='aerials16' visible=qps.aerials16}}
 
   {{#if mapMouseover.highlightedLotFeatures}}


### PR DESCRIPTION
This PR adds a raster layer for the digital tax map, which is proxied through [`labs-zola-search-api`](https://github.com/NYCPlanning/labs-zola-search-api/blob/master/utils/doitt-tiles.js) to manipulate the images into fitting into a standard webmercator tile grid.

Minzoom for the source and the layer is 15.