### PR TITLE
add centroids data, remove non-ntas

### DIFF
--- a/app/layer-groups/neighborhood-tabulation-areas.js
+++ b/app/layer-groups/neighborhood-tabulation-areas.js
@@ -7,7 +7,10 @@ export default {
   title: 'Neighborhood Tabulation Areas',
   visible: false,
   type: 'carto', // raster, vector, geojson, or carto
-  sql: ['SELECT the_geom_webmercator, ntaname FROM support_admin_ntaboundaries'],
+  sql: [
+    'SELECT the_geom_webmercator, ntaname FROM support_admin_ntaboundaries WHERE ntaname NOT ILIKE \'park-cemetery-etc%\'',
+    'SELECT ST_Centroid(the_geom_webmercator) as the_geom_webmercator, ntaname FROM support_admin_ntaboundaries WHERE ntaname NOT ILIKE \'park-cemetery-etc%\'',
+  ],
   layers: [
     {
       layer: {
@@ -22,7 +25,7 @@ export default {
       layer: {
         id: 'nta-label',
         type: 'symbol',
-        'source-layer': 'layer0',
+        'source-layer': 'layer1',
         minzoom: 12,
         paint: paint.labels,
         layout: labelLayout('ntaname'),


### PR DESCRIPTION
Adds a centroids layer to the NTA vector tile for use in label placement,
removes non-nta features from query (parks, cemeteries, etc)