### PR TITLE
add badge Sass, stub in layer-palette-accordion-title badge

### DIFF
--- a/app/components/layer-menu-item.js
+++ b/app/components/layer-menu-item.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 import { computed } from 'ember-decorators/object'; // eslint-disable-line
-import { ParentMixin } from 'ember-composability-tools';
+import { ParentMixin, ChildMixin } from 'ember-composability-tools';
 
 const { service } = Ember.inject;
 const { alias } = Ember.computed;
 
-export default Ember.Component.extend(ParentMixin, {
+export default Ember.Component.extend(ParentMixin, ChildMixin, {
   registeredLayers: service(),
   mainMap: service(),
   visible: alias('layer.visible'),

--- a/app/components/layer-palette-accordion.js
+++ b/app/components/layer-palette-accordion.js
@@ -1,6 +1,15 @@
 import Ember from 'ember';
+import { ParentMixin } from 'ember-composability-tools';
+import { computed } from 'ember-decorators/object'; // eslint-disable-line
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(ParentMixin, {
   classNames: ['layer-palette-accordion'],
   closed: true,
+
+  didInsertElement() {
+    this.set('numberVisible', Ember.computed('childComponents.@each.visible', function() {
+      const childComponents = this.get('childComponents');
+      return childComponents.filterBy('visible', true).length;
+    }));
+  },
 });

--- a/app/styles/_settings.scss
+++ b/app/styles/_settings.scss
@@ -252,13 +252,13 @@ $accordionmenu-arrow-size: 6px;
 // 9. Badge
 // --------
 
-$badge-background: $primary-color;
-$badge-color: $white;
-$badge-color-alt: $black;
+$badge-background: $secondary-color;
+$badge-color: $black;
+$badge-color-alt: $white;
 $badge-palette: $foundation-palette;
-$badge-padding: 0.3em;
-$badge-minwidth: 2.1em;
-$badge-font-size: 0.6rem;
+$badge-padding: rem-calc(1);
+$badge-minwidth: rem-calc(17);
+$badge-font-size: rem-calc(10);
 
 // 10. Breadcrumbs
 // ---------------

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -37,7 +37,7 @@ $lu-gray: #5F5F60;
 @include foundation-button;
 // @include foundation-accordion;
 // @include foundation-accordion-menu;
-// @include foundation-badge;
+@include foundation-badge;
 // @include foundation-breadcrumbs;
 // @include foundation-button-group;
 // @include foundation-callout;

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -31,7 +31,7 @@ h6,
 
 
 //
-// Typography helper classes
+// Badges
 // --------------------------------------------------
 .badge {
   font-weight: $global-weight-normal;

--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -29,8 +29,19 @@ h6,
   color: $dark-gray;
 }
 
+
 //
-// Typograhpy helper classes
+// Typography helper classes
+// --------------------------------------------------
+.badge {
+  font-weight: $global-weight-normal;
+  line-height: 1.5;
+  vertical-align: middle;
+}
+
+
+//
+// Typography helper classes
 // --------------------------------------------------
 .nowrap {
   white-space: nowrap;

--- a/app/templates/components/layer-palette-accordion.hbs
+++ b/app/templates/components/layer-palette-accordion.hbs
@@ -1,4 +1,9 @@
-<h5 {{action (mut closed) (not closed)}} class="layer-palette-accordion-title {{if closed 'closed'}}">{{title}}</h5>
+<h5 {{action (mut closed) (not closed)}} class="layer-palette-accordion-title {{if closed 'closed'}}">
+  {{title}}
+  {{#if true}}
+  <span class="badge">3</span>
+  {{/if}}
+</h5>
 <ul class="layers-collection {{if closed 'hide'}}">
   {{yield}}
 </ul>

--- a/app/templates/components/layer-palette-accordion.hbs
+++ b/app/templates/components/layer-palette-accordion.hbs
@@ -1,7 +1,7 @@
 <h5 {{action (mut closed) (not closed)}} class="layer-palette-accordion-title {{if closed 'closed'}}">
   {{title}}
-  {{#if true}}
-  <span class="badge">3</span>
+  {{#if numberVisible}}
+    <span class="badge">{{numberVisible}}</span>
   {{/if}}
 </h5>
 <ul class="layers-collection {{if closed 'hide'}}">

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -3,6 +3,7 @@
 {{else}}
   <button {{action (mut closed) (not closed)}} class="close-button" aria-label="Close Map Layers" type="button"><span aria-hidden="true">&times;</span></button>
 {{/if}}
+
 <div id="layers-menu" class="{{if closed 'show-for-medium'}} hide-for-print">
   {{#layer-palette-accordion
     closed=false

--- a/tests/integration/components/layer-menu-item-test.js
+++ b/tests/integration/components/layer-menu-item-test.js
@@ -10,7 +10,7 @@ test('it renders', function(assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{layer-menu-item title='test'}}`);
+  this.render(hbs`{{#layer-palette-accordion}}{{layer-menu-item title='test'}}{{/layer-palette-accordion}}`);
 
   assert.ok(this);
 });


### PR DESCRIPTION
This PR…
- [x] Adds the Foundation Badge component Sass
- [x] Add badge markup to the layer palette accordion title
- [ ] Adds logic for calculating how many layer groups are visible within a `layer-palette-accordion` component 

Closes #129.