### PR TITLE
Zoning Districts checkbox filters

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -23,42 +23,40 @@ export const mapQueryParams =
     merge(
       queryParams,
       {
-        'comm-type': {
-          defaultValue: '',
-        },
-        c11: {
-          defaultValue: true,
-        },
-        c12: {
-          defaultValue: true,
-        },
-        c13: {
-          defaultValue: true,
-        },
-        c14: {
-          defaultValue: true,
-        },
-        c15: {
-          defaultValue: true,
-        },
-        c21: {
-          defaultValue: true,
-        },
-        c22: {
-          defaultValue: true,
-        },
-        c23: {
-          defaultValue: true,
-        },
-        c24: {
-          defaultValue: true,
-        },
-        c25: {
-          defaultValue: true,
-        },
-        allChecked: {
-          defaultValue: [],
-        },
+        'comm-type': { defaultValue: '' },
+        BP: { defaultValue: true },
+        C1: { defaultValue: true },
+        C2: { defaultValue: true },
+        C3: { defaultValue: true },
+        C4: { defaultValue: true },
+        C5: { defaultValue: true },
+        C6: { defaultValue: true },
+        C7: { defaultValue: true },
+        C8: { defaultValue: true },
+        M1: { defaultValue: true },
+        M2: { defaultValue: true },
+        M3: { defaultValue: true },
+        PA: { defaultValue: true },
+        R1: { defaultValue: true },
+        R2: { defaultValue: true },
+        R3: { defaultValue: true },
+        R4: { defaultValue: true },
+        R5: { defaultValue: true },
+        R6: { defaultValue: true },
+        R7: { defaultValue: true },
+        R8: { defaultValue: true },
+        R9: { defaultValue: true },
+        c11: { defaultValue: true },
+        c12: { defaultValue: true },
+        c13: { defaultValue: true },
+        c14: { defaultValue: true },
+        c15: { defaultValue: true },
+        c21: { defaultValue: true },
+        c22: { defaultValue: true },
+        c23: { defaultValue: true },
+        c24: { defaultValue: true },
+        c25: { defaultValue: true },
+        allChecked: { defaultValue: [] },
       },
     ),
   );

--- a/app/styles/modules/_m-layer-palette.scss
+++ b/app/styles/modules/_m-layer-palette.scss
@@ -101,7 +101,8 @@ $layer-palette-hover-color: rgba($dark-gray,0.08);
       padding-left: $layer-palette-padding*3;
     }
 
-    &.columns-2 {
+    &.columns-2,
+    &.columns-3 {
       padding: 0 $layer-palette-padding*2 0 $layer-palette-padding*3;
       column-count: 2;
       column-gap: $layer-palette-padding;
@@ -109,6 +110,9 @@ $layer-palette-hover-color: rgba($dark-gray,0.08);
       label {
         padding-left: $layer-palette-padding;
       }
+    }
+    &.columns-3 {
+      column-count: 3;
     }
   }
 

--- a/app/styles/modules/_m-layer-palette.scss
+++ b/app/styles/modules/_m-layer-palette.scss
@@ -83,6 +83,10 @@ $layer-palette-hover-color: rgba($dark-gray,0.08);
 
 .layer-menu-item--group-checkboxes {
 
+  > li {
+    margin-bottom: $layer-palette-padding;
+  }
+
   label {
     padding: 0 $layer-palette-padding;
     font-size: inherit;

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -18,11 +18,10 @@
             <ul class="layer-menu-item--group-checkboxes">
               <li>
                 <label>{{group-checkbox
-                  refs=(array 'qps.BP' 'qps.C1' 'qps.C2' 'qps.C3' 'qps.C4' 'qps.C5' 'qps.C6' 'qps.C7' 'qps.C8' 'qps.M1' 'qps.M2' 'qps.M3' 'qps.PA' 'qps.R1' 'qps.R2' 'qps.R3' 'qps.R4' 'qps.R5' 'qps.R6' 'qps.R7' 'qps.R8' 'qps.R9')
-                  values=(array qps.BP qps.C1 qps.C2 qps.C3 qps.C4 qps.C5 qps.C6 qps.C7 qps.C8 qps.M1 qps.M2 qps.M3 qps.PA qps.R1 qps.R2 qps.R3 qps.R4 qps.R5 qps.R6 qps.R7 qps.R8 qps.R9)
-                  scope=qps}}Select All</label>
+                  refs=(array 'qps.C1' 'qps.C2' 'qps.C3' 'qps.C4' 'qps.C5' 'qps.C6' 'qps.C7' 'qps.C8')
+                  values=(array qps.C1 qps.C2 qps.C3 qps.C4 qps.C5 qps.C6 qps.C7 qps.C8)
+                  scope=qps}}Select All Commercial Districts</label>
                 <ul class="nested columns-3">
-                  <li><label>{{multiSelect.checkbox value='BP' checked=qps.BP}}BP</label></li>
                   <li><label>{{multiSelect.checkbox value='C1' checked=qps.C1}}C1</label></li>
                   <li><label>{{multiSelect.checkbox value='C2' checked=qps.C2}}C2</label></li>
                   <li><label>{{multiSelect.checkbox value='C3' checked=qps.C3}}C3</label></li>
@@ -31,10 +30,25 @@
                   <li><label>{{multiSelect.checkbox value='C6' checked=qps.C6}}C6</label></li>
                   <li><label>{{multiSelect.checkbox value='C7' checked=qps.C7}}C7</label></li>
                   <li><label>{{multiSelect.checkbox value='C8' checked=qps.C8}}C8</label></li>
+                </ul>
+              </li>
+              <li>
+                <label>{{group-checkbox
+                  refs=(array 'qps.M1' 'qps.M2' 'qps.M3')
+                  values=(array qps.M1 qps.M2 qps.M3)
+                  scope=qps}}Select All Manufacturing Districts</label>
+                <ul class="nested columns-3">
                   <li><label>{{multiSelect.checkbox value='M1' checked=qps.M1}}M1</label></li>
                   <li><label>{{multiSelect.checkbox value='M2' checked=qps.M2}}M2</label></li>
                   <li><label>{{multiSelect.checkbox value='M3' checked=qps.M3}}M3</label></li>
-                  <li><label>{{multiSelect.checkbox value='PA' checked=qps.PA}}PA</label></li>
+                </ul>
+              </li>
+              <li>
+                <label>{{group-checkbox
+                  refs=(array 'qps.R1' 'qps.R2' 'qps.R3' 'qps.R4' 'qps.R5' 'qps.R6' 'qps.R7' 'qps.R8' 'qps.R9')
+                  values=(array qps.R1 qps.R2 qps.R3 qps.R4 qps.R5 qps.R6 qps.R7 qps.R8 qps.R9)
+                  scope=qps}}Select All Residential Districts</label>
+                <ul class="nested columns-3">
                   <li><label>{{multiSelect.checkbox value='R1' checked=qps.R1}}R1</label></li>
                   <li><label>{{multiSelect.checkbox value='R2' checked=qps.R2}}R2</label></li>
                   <li><label>{{multiSelect.checkbox value='R3' checked=qps.R3}}R3</label></li>
@@ -46,6 +60,8 @@
                   <li><label>{{multiSelect.checkbox value='R9' checked=qps.R9}}R9</label></li>
                 </ul>
               </li>
+              <li><label>{{multiSelect.checkbox value='PA' checked=qps.PA}}Parks</label></li>
+              <li><label>{{multiSelect.checkbox value='BP' checked=qps.BP}}Battery Park</label></li>
             </ul>
         {{/layer-multi-select-control}}
       {{/if}}
@@ -108,9 +124,6 @@
                   <li><label>{{multiSelect.checkbox value='C1-5' checked=qps.c15}}C1-5</label></li>
                 </ul>
               </li>
-            </ul>
-
-            <ul class="layer-menu-item--group-checkboxes">
               <li>
                 <label>{{group-checkbox
                   refs=(array 'qps.c21' 'qps.c22' 'qps.c23' 'qps.c24' 'qps.c25')

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -11,23 +11,43 @@
     {{#layer-menu-item
       for='zoning-districts' as |item|}}
       {{#if item.layer.visible}}
-        {{#item.multi-select
-          allChecked=qps.allChecked
-          column='primaryzone' as |multiSelect|}}
-          {{#power-select-multiple
-            options=(await
-                (get-unique-options-for 'primaryzone' item.layer.config.sql)
-              )
-            selected=multiSelect.allChecked
-            placeholder="Select Zones"
-            onchange=(queue
-                (action item.updateSql 'buildMultiSelectSQL' 'primaryzone')
-                (action (mut multiSelect.allChecked))
-              )
-            as |name|}}
-            {{name}}
-          {{/power-select-multiple}}
-        {{/item.multi-select}}
+        {{#layer-multi-select-control
+          column='primaryzone'
+          parentComponent=item.layer
+          as |multiSelect|}}
+            <ul class="layer-menu-item--group-checkboxes">
+              <li>
+                <label>{{group-checkbox
+                  refs=(array 'qps.BP' 'qps.C1' 'qps.C2' 'qps.C3' 'qps.C4' 'qps.C5' 'qps.C6' 'qps.C7' 'qps.C8' 'qps.M1' 'qps.M2' 'qps.M3' 'qps.PA' 'qps.R1' 'qps.R2' 'qps.R3' 'qps.R4' 'qps.R5' 'qps.R6' 'qps.R7' 'qps.R8' 'qps.R9')
+                  values=(array qps.BP qps.C1 qps.C2 qps.C3 qps.C4 qps.C5 qps.C6 qps.C7 qps.C8 qps.M1 qps.M2 qps.M3 qps.PA qps.R1 qps.R2 qps.R3 qps.R4 qps.R5 qps.R6 qps.R7 qps.R8 qps.R9)
+                  scope=qps}}Select All</label>
+                <ul class="nested columns-3">
+                  <li><label>{{multiSelect.checkbox value='BP' checked=qps.BP}}BP</label></li>
+                  <li><label>{{multiSelect.checkbox value='C1' checked=qps.C1}}C1</label></li>
+                  <li><label>{{multiSelect.checkbox value='C2' checked=qps.C2}}C2</label></li>
+                  <li><label>{{multiSelect.checkbox value='C3' checked=qps.C3}}C3</label></li>
+                  <li><label>{{multiSelect.checkbox value='C4' checked=qps.C4}}C4</label></li>
+                  <li><label>{{multiSelect.checkbox value='C5' checked=qps.C5}}C5</label></li>
+                  <li><label>{{multiSelect.checkbox value='C6' checked=qps.C6}}C6</label></li>
+                  <li><label>{{multiSelect.checkbox value='C7' checked=qps.C7}}C7</label></li>
+                  <li><label>{{multiSelect.checkbox value='C8' checked=qps.C8}}C8</label></li>
+                  <li><label>{{multiSelect.checkbox value='M1' checked=qps.M1}}M1</label></li>
+                  <li><label>{{multiSelect.checkbox value='M2' checked=qps.M2}}M2</label></li>
+                  <li><label>{{multiSelect.checkbox value='M3' checked=qps.M3}}M3</label></li>
+                  <li><label>{{multiSelect.checkbox value='PA' checked=qps.PA}}PA</label></li>
+                  <li><label>{{multiSelect.checkbox value='R1' checked=qps.R1}}R1</label></li>
+                  <li><label>{{multiSelect.checkbox value='R2' checked=qps.R2}}R2</label></li>
+                  <li><label>{{multiSelect.checkbox value='R3' checked=qps.R3}}R3</label></li>
+                  <li><label>{{multiSelect.checkbox value='R4' checked=qps.R4}}R4</label></li>
+                  <li><label>{{multiSelect.checkbox value='R5' checked=qps.R5}}R5</label></li>
+                  <li><label>{{multiSelect.checkbox value='R6' checked=qps.R6}}R6</label></li>
+                  <li><label>{{multiSelect.checkbox value='R7' checked=qps.R7}}R7</label></li>
+                  <li><label>{{multiSelect.checkbox value='R8' checked=qps.R8}}R8</label></li>
+                  <li><label>{{multiSelect.checkbox value='R9' checked=qps.R9}}R9</label></li>
+                </ul>
+              </li>
+            </ul>
+        {{/layer-multi-select-control}}
       {{/if}}
     {{/layer-menu-item}}
 


### PR DESCRIPTION
This PR switches the Zoning Districts layer to use checkboxes instead of power-select for its filters.

Closes #102. 