### PR TITLE
make zoning fill fade out between zoom 15 and 16

### DIFF
--- a/app/layer-groups/zoning-districts.js
+++ b/app/layer-groups/zoning-districts.js
@@ -40,7 +40,12 @@ export default {
               ['R9', '#f2f618'],
             ],
           },
-          'fill-opacity': 0.3,
+          'fill-opacity': {
+            stops: [
+              [15, 0.3],
+              [16, 0],
+            ],
+          },
           'fill-antialias': true,
         },
       },


### PR DESCRIPTION
Fade zoning colors out as tax lots fade in, like:

![sep-28-2017 22-16-20](https://user-images.githubusercontent.com/1833820/30998267-3b75694e-a49b-11e7-93e4-2247541cb52c.gif)
