### PR TITLE
214 zma date tooltips

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -87,7 +87,7 @@ export default Ember.Controller.extend(mapQueryParams.Mixin, {
     routeToLot(e) {
       const map = e.target;
       // only query layers that are available in the map
-      const layers = ['pluto-fill', 'zma-fill', 'zd-fill'].filter(layer => map.getLayer(layer));
+      const layers = ['pluto-fill', 'zma-fill', 'zmacert-fill', 'zd-fill'].filter(layer => map.getLayer(layer));
       const feature = map.queryRenderedFeatures(e.point, { layers })[0];
       const { bbl, ulurpno, zonedist } = feature.properties;
 

--- a/app/layer-groups/zoning-map-amendments-pending.js
+++ b/app/layer-groups/zoning-map-amendments-pending.js
@@ -33,6 +33,8 @@ export default {
           'fill-opacity': 0.6,
         },
       },
+      highlightable: true,
+      tooltipTemplate: '{{{project_na}}}',
     },
   ],
 };

--- a/app/layer-groups/zoning-map-amendments.js
+++ b/app/layer-groups/zoning-map-amendments.js
@@ -34,7 +34,7 @@ export default {
         },
       },
       highlightable: true,
-      tooltipTemplate: '{{project_na}} - {{status}}',
+      tooltipTemplate: '{{{project_na}}} - Effective {{{effective}}}',
     },
   ],
 };

--- a/app/layer-groups/zoning-map-amendments.js
+++ b/app/layer-groups/zoning-map-amendments.js
@@ -34,7 +34,7 @@ export default {
         },
       },
       highlightable: true,
-      tooltipTemplate: '{{{project_na}}} - Effective {{{effective}}}',
+      tooltipTemplate: '{{{project_na}}} - Effective {{{effectiveformatted}}}',
     },
   ],
 };

--- a/app/sources/supporting-zoning.js
+++ b/app/sources/supporting-zoning.js
@@ -44,7 +44,7 @@ export default {
     },
     {
       id: 'zoning-map-amendments-pending',
-      sql: 'SELECT the_geom_webmercator, ulurpno, status FROM support_nyzma WHERE status = \'Certified\'',
+      sql: 'SELECT the_geom_webmercator, ulurpno, status, project_na FROM support_nyzma WHERE status = \'Certified\'',
     },
   ],
 };

--- a/app/sources/zoning-map-amendments.js
+++ b/app/sources/zoning-map-amendments.js
@@ -4,7 +4,7 @@ export default {
   'source-layers': [
     {
       id: 'zoning-map-amendments',
-      sql: 'SELECT the_geom_webmercator, ulurpno, status, project_na FROM support_nyzma',
+      sql: 'SELECT * FROM (SELECT the_geom_webmercator, to_char(effective, \'MM/DD/YYYY\') as effective, ulurpno, status, project_na FROM support_nyzma WHERE status = \'Adopted\') a',
     },
   ],
 };

--- a/app/sources/zoning-map-amendments.js
+++ b/app/sources/zoning-map-amendments.js
@@ -4,7 +4,7 @@ export default {
   'source-layers': [
     {
       id: 'zoning-map-amendments',
-      sql: 'SELECT * FROM (SELECT the_geom_webmercator, to_char(effective, \'MM/DD/YYYY\') as effective, ulurpno, status, project_na FROM support_nyzma WHERE status = \'Adopted\') a',
+      sql: 'SELECT * FROM (SELECT the_geom_webmercator, to_char(effective, \'MM/DD/YYYY\') as effectiveformatted, effective, ulurpno, status, project_na FROM support_nyzma WHERE status = \'Adopted\') a',
     },
   ],
 };


### PR DESCRIPTION
This PR 
- adds effective date to the tooltips for zoning map amendments.
- adds tooltips with ZMA name to certified zoning map amendments.
- makes certified zoning map amendments clickable (routing to the zma route)

Based on `cw-map-improvements`, so don't merge until we are clear on the `source` and `layer` refactoring.

Closes #214