### PR TITLE
141 zoning fitbounds

### DIFF
--- a/app/components/map-search.js
+++ b/app/components/map-search.js
@@ -110,6 +110,7 @@ export default Ember.Component.extend({
       }
 
       if (result.type === 'zoning-district') {
+        mainMap.set('shouldFitBounds', true);
         this.transitionTo('zoning-district', result.label);
       }
 

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -5,6 +5,7 @@ import { computed } from 'ember-decorators/object'; // eslint-disable-line
 
 import layerGroups from '../layer-groups';
 
+const { service } = Ember.inject;
 const { merge } = Ember;
 
 const queryParams = Object.keys(layerGroups)
@@ -73,6 +74,8 @@ export default Ember.Controller.extend(mapQueryParams.Mixin, {
     this.set('qps', proxy);
   },
 
+  mainMap: service(),
+
   @computed('queryParamsState')
   isDefault(state) {
     const values = Object.values(state);
@@ -101,6 +104,8 @@ export default Ember.Controller.extend(mapQueryParams.Mixin, {
       }
 
       if (zonedist) {
+        const mainMap = this.get('mainMap');
+        mainMap.set('shouldFitBounds', false);
         this.transitionToRoute('zoning-district', zonedist);
       }
     },

--- a/app/layer-groups/zoning-districts.js
+++ b/app/layer-groups/zoning-districts.js
@@ -48,7 +48,7 @@ export default {
         },
       },
       highlightable: true,
-      tooltipTemplate: '{{zonedist}}',
+      tooltipTemplate: 'Zoning District {{zonedist}}',
     },
     {
       layer: {

--- a/app/layers/selected-lot.js
+++ b/app/layers/selected-lot.js
@@ -4,28 +4,36 @@ const selectedLayers = {
     type: 'fill',
     source: 'selected-lot',
     paint: {
-      'fill-opacity': 0.1,
-      'fill-color': 'red',
+      'fill-opacity': 0.3,
+      'fill-color': 'rgba(113, 113, 113, 1)',
     },
   },
   line: {
     id: 'selected-line',
     type: 'line',
     source: 'selected-lot',
-    paint: {
-      'line-opacity': 0.6,
-      // 'line-dasharray': [1, 1],
-      'line-color': 'red',
-      'line-width': {
-        stops: [
-          [13, 1],
-          [15, 4],
-        ],
-      },
-      'line-dasharray': [0, 1.5],
-    },
     layout: {
       'line-cap': 'round',
+    },
+    paint: {
+      'line-opacity': 0.6,
+      'line-color': 'rgba(41, 34, 191, 1)',
+      'line-width': {
+        stops: [
+          [
+            13,
+            1.5,
+          ],
+          [
+            15,
+            8,
+          ],
+        ],
+      },
+      'line-dasharray': [
+        2,
+        1.5,
+      ],
     },
   },
 };

--- a/app/routes/zoning-district.js
+++ b/app/routes/zoning-district.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object'; // eslint-disable-line
 
 const { service } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Route.extend({
   mainMap: service(),
@@ -13,9 +15,13 @@ export default Ember.Route.extend({
     this.set('mainMap.selected', model);
   },
 
+  bounds: alias('mainMap.bounds'),
+
   actions: {
-    didTransition() {
-      this.set('mainMap.shouldFitBounds', true);
+    fitBounds() {
+      const mainMap = this.get('mainMap');
+      const map = mainMap.mapInstance;
+      map.fitBounds(this.get('bounds'));
     },
   },
 });

--- a/app/templates/zoning-district.hbs
+++ b/app/templates/zoning-district.hbs
@@ -6,6 +6,10 @@
 
   <p>More Info About this Zoning type</p>
   <a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/{{model.primaryzone}}.page" target="_blank">Link</a>
+
+  <br/>
+
+  <button {{action "fitBounds"}} class="button">Fit Map to all {{model.id}} districts</button>
 </div>
 
 {{outlet}}

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:application', 'Unit | Controller | application', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:mainMap']
 });
 
 // Replace this with your real tests.


### PR DESCRIPTION
This PR:

- Adds logic to leave the map alone when routing to a zoning district via map click
- Make the map fitbounds for the zoning district when routing from a search result
- Adds a "Fit map to all XX districts" button, so the user can see all if they choose.