### PR TITLE
style admin layers with legend

### DIFF
--- a/app/components/layer-menu-item.js
+++ b/app/components/layer-menu-item.js
@@ -21,6 +21,11 @@ export default Ember.Component.extend(ParentMixin, ChildMixin, {
     return title;
   },
 
+  @computed('layer.config.legendColor')
+  legendColor(legendColor) {
+    return legendColor;
+  },
+
   @computed('layer.config.titleTooltip')
   titleTooltip(titleTooltip) {
     return titleTooltip;

--- a/app/helpers/admin-boundary-styles.js
+++ b/app/helpers/admin-boundary-styles.js
@@ -1,12 +1,12 @@
 const adminBoundaryStyles = {
   paint: {
     lines: {
-      'line-color': '#717171',
-      'line-opacity': 0.7,
+      'line-color': '#444',
+      'line-opacity': 0.3,
       'line-width': {
         stops: [
-          [9, 1],
-          [14, 4],
+          [11, 1],
+          [16, 3],
         ],
       },
     },

--- a/app/layer-groups/assemblydistricts.js
+++ b/app/layer-groups/assemblydistricts.js
@@ -5,8 +5,27 @@ const { paint, layout, labelLayout } = adminBoundaryStyles;
 export default {
   id: 'assemblydistricts',
   title: 'New York State Assembly Districts',
+  legendColor: '#8A76F5',
   visible: false,
   layers: [
+    {
+      layer: {
+        id: 'assemblydistricts-line-glow',
+        type: 'line',
+        source: 'admin-boundaries',
+        'source-layer': 'ny-assembly-districts',
+        paint: {
+          'line-color': '#8A76F5',
+          'line-opacity': 0.2,
+          'line-width': {
+            stops: [
+              [11, 3],
+              [16, 6],
+            ],
+          },
+        },
+      },
+    },
     {
       layer: {
         id: 'assemblydistricts-line',

--- a/app/layer-groups/boroughs.js
+++ b/app/layer-groups/boroughs.js
@@ -1,12 +1,31 @@
 import adminBoundaryStyles from '../helpers/admin-boundary-styles';
 
-const { paint, layout, labelLayout } = adminBoundaryStyles;
+const { paint, layout } = adminBoundaryStyles;
 
 export default {
   id: 'boroughs',
   title: 'Boroughs',
+  legendColor: '#F5B176',
   visible: false,
   layers: [
+    {
+      layer: {
+        id: 'boroughs-line-glow',
+        type: 'line',
+        source: 'admin-boundaries',
+        'source-layer': 'boroughs',
+        paint: {
+          'line-color': '#F5B176',
+          'line-opacity': 0.2,
+          'line-width': {
+            stops: [
+              [11, 3],
+              [16, 6],
+            ],
+          },
+        },
+      },
+    },
     {
       layer: {
         id: 'boroughs-line',
@@ -15,16 +34,6 @@ export default {
         'source-layer': 'boroughs',
         paint: paint.lines,
         layout: layout.lines,
-      },
-    },
-    {
-      layer: {
-        id: 'boroughs-label',
-        type: 'symbol',
-        source: 'admin-boundaries',
-        'source-layer': 'boroughs',
-        paint: paint.labels,
-        layout: labelLayout('boroname'),
       },
     },
   ],

--- a/app/layer-groups/communitydistricts.js
+++ b/app/layer-groups/communitydistricts.js
@@ -5,8 +5,27 @@ const { paint, layout, labelLayout } = adminBoundaryStyles;
 export default {
   id: 'community-districts',
   title: 'Community Districts',
+  legendColor: '#76F578',
   visible: false,
   layers: [
+    {
+      layer: {
+        id: 'community-districts-line-glow',
+        type: 'line',
+        source: 'admin-boundaries',
+        'source-layer': 'community-districts',
+        paint: {
+          'line-color': '#76F578',
+          'line-opacity': 0.2,
+          'line-width': {
+            stops: [
+              [11, 3],
+              [16, 6],
+            ],
+          },
+        },
+      },
+    },
     {
       layer: {
         id: 'community-districts-line',

--- a/app/layer-groups/neighborhood-tabulation-areas.js
+++ b/app/layer-groups/neighborhood-tabulation-areas.js
@@ -5,8 +5,27 @@ const { paint, layout, labelLayout } = adminBoundaryStyles;
 export default {
   id: 'neighborhood-tabulation-areas',
   title: 'Neighborhood Tabulation Areas',
+  legendColor: '#F576CC',
   visible: false,
   layers: [
+    {
+      layer: {
+        id: 'nta-line-glow',
+        type: 'line',
+        source: 'admin-boundaries',
+        'source-layer': 'neighborhood-tabulation-areas',
+        paint: {
+          'line-color': '#F576CC',
+          'line-opacity': 0.2,
+          'line-width': {
+            stops: [
+              [11, 3],
+              [16, 6],
+            ],
+          },
+        },
+      },
+    },
     {
       layer: {
         id: 'nta-line',

--- a/app/layer-groups/nyccouncildistricts.js
+++ b/app/layer-groups/nyccouncildistricts.js
@@ -5,8 +5,27 @@ const { paint, layout, labelLayout } = adminBoundaryStyles;
 export default {
   id: 'nyccouncildistricts',
   title: 'NYC Council Districts',
+  legendColor: '#76CAF5',
   visible: false,
   layers: [
+    {
+      layer: {
+        id: 'nyccouncildistricts-line-glow',
+        type: 'line',
+        source: 'admin-boundaries',
+        'source-layer': 'nyc-council-districts',
+        paint: {
+          'line-color': '#76CAF5',
+          'line-opacity': 1,
+          'line-width': {
+            stops: [
+              [11, 3],
+              [16, 6],
+            ],
+          },
+        },
+      },
+    },
     {
       layer: {
         id: 'nyccouncildistricts-line',

--- a/app/layer-groups/nysenatedistricts.js
+++ b/app/layer-groups/nysenatedistricts.js
@@ -5,8 +5,27 @@ const { paint, layout, labelLayout } = adminBoundaryStyles;
 export default {
   id: 'nysenatedistricts',
   title: 'New York State Senate Districts',
+  legendColor: '#E4F576',
   visible: false,
   layers: [
+    {
+      layer: {
+        id: 'nysenatedistricts-line-glow',
+        type: 'line',
+        source: 'admin-boundaries',
+        'source-layer': 'ny-senate-districts',
+        paint: {
+          'line-color': '#E4F576',
+          'line-opacity': 1,
+          'line-width': {
+            stops: [
+              [11, 3],
+              [16, 6],
+            ],
+          },
+        },
+      },
+    },
     {
       layer: {
         id: 'nysenatedistricts-line',

--- a/app/styles/modules/_m-layer-palette.scss
+++ b/app/styles/modules/_m-layer-palette.scss
@@ -172,3 +172,17 @@ $layer-palette-hover-color: rgba($dark-gray,0.08);
   display: flex;
   flex-direction: column-reverse;
 }
+
+.layer-group-legend {
+  display: inline-block;
+  width: 1rem;
+  height: rem-calc(6);
+  vertical-align: middle;
+  position: relative;
+  top: -0.1em;
+  background-color: #444;
+  border: rem-calc(2) solid #fff;
+  border-right-width: 0;
+  border-left-width: 0;
+  opacity: 0.75;
+}

--- a/app/templates/components/layer-menu-item.hbs
+++ b/app/templates/components/layer-menu-item.hbs
@@ -8,7 +8,7 @@
     {{/if}}
     {{switch-toggle checked=visible}}
     {{title}}
-    {{#if legendColor}}<span class="layer-group-legend" style="border-color:{{legendColor}};"></span>{{/if}}
+    {{#if visible}}{{#if legendColor}}<span class="layer-group-legend" style="border-color:{{legendColor}};"></span>{{/if}}{{/if}}
     {{#if titleTooltip}}{{info-tooltip tip=titleTooltip}}{{/if}}
   </div>
   {{yield (hash

--- a/app/templates/components/layer-menu-item.hbs
+++ b/app/templates/components/layer-menu-item.hbs
@@ -7,7 +7,9 @@
       </span>
     {{/if}}
     {{switch-toggle checked=visible}}
-    {{title}} {{#if titleTooltip}}{{info-tooltip tip=titleTooltip}}{{/if}}
+    {{title}}
+    {{#if legendColor}}<span class="layer-group-legend" style="border-color:{{legendColor}};"></span>{{/if}}
+    {{#if titleTooltip}}{{info-tooltip tip=titleTooltip}}{{/if}}
   </div>
   {{yield (hash
     layer=layer


### PR DESCRIPTION
This PR adds custom styling for each admin boundary layer, along with a `.layer-group-legend`. 

Closes #193. 

Edit: Misnamed this branch. It's not for 198. 😬 