### PR TITLE
move highlight layer on mouseover

### DIFF
--- a/app/services/map-mouseover.js
+++ b/app/services/map-mouseover.js
@@ -73,15 +73,25 @@ export default Ember.Service.extend({
     const layers = this.get('registeredLayers.highlightableAndVisibleLayerIds');
     const features = map.queryRenderedFeatures(e.point, { layers });
 
-
     if (features.length > 0) {
       map.getCanvas().style.cursor = 'pointer';
 
 
       const thisFeature = features[0];
-      const prevFeature = this.get('highlightedLotFeatures')[0];
-      if (!prevFeature || thisFeature.id !== prevFeature.id) this.set('highlightedLotFeatures', [thisFeature]);
 
+      const prevFeature = this.get('highlightedLotFeatures')[0];
+      if (!prevFeature || thisFeature.id !== prevFeature.id) {
+        this.set('highlightedLotFeatures', [thisFeature]);
+        // move the layer
+        const layerId = thisFeature.layer.id;
+        const beforeLayerId = map.getStyle().layers.reduce((acc, curr) => {
+          if (curr.id === layerId) return 'hit';
+          if (acc === 'hit') return curr;
+          return acc;
+        }).id;
+
+        map.moveLayer('highlighted-lot', beforeLayerId);
+      }
 
       this.set('tooltipTemplate', this.get('registeredLayers').getTooltipTemplate(thisFeature.layer.id));
     } else {


### PR DESCRIPTION
This PR changes the ordering position of the `highlighted-lot` layer during the mousemovehandler, causing it to be rendered directly above the layer it is highlighting.  (It used to always be "on top", which shaded layers that were rendered above the feature of interest.