### PR TITLE
better tax lot palette

### DIFF
--- a/app/layer-groups/pluto.js
+++ b/app/layer-groups/pluto.js
@@ -1,6 +1,6 @@
 export default {
   id: 'pluto',
-  title: 'PLUTO (Tax Lots)',
+  title: 'Tax Lots',
   layers: [
     {
       layer: {

--- a/app/styles/modules/_m-layer-palette.scss
+++ b/app/styles/modules/_m-layer-palette.scss
@@ -81,6 +81,15 @@ $layer-palette-hover-color: rgba($dark-gray,0.08);
 
 }
 
+.checkbox-wrapper {
+  padding: $layer-palette-padding/2 $layer-palette-padding;
+
+  &:hover {
+    cursor: pointer;
+    background-color: $layer-palette-hover-color;
+  }
+}
+
 .layer-menu-item--group-checkboxes {
 
   > li {
@@ -149,7 +158,7 @@ $layer-palette-hover-color: rgba($dark-gray,0.08);
 }
 
 .layer-key {
-  padding: $layer-palette-padding;
+  padding: 0 $layer-palette-padding $layer-palette-padding;
   font-size: rem-calc(10);
   line-height: 1.2;
 

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -71,32 +71,32 @@
         {{info-tooltip iconName='warning' tip='Zoom in more to see'}}
       {{/if}}
       {{#if item.layer.visible}}
-        <div class="layer-menu-item"
+        <div class="checkbox-wrapper"
           onclick={{queue
-            (action 'toggleFill')
-            (action item.updatePaintFor
-              'pluto-fill'
-              (if plutoFill (hash fill-opacity=0.7) (hash fill-opacity=0))
-            )}}>
+          (action 'toggleFill')
+          (action item.updatePaintFor
+            'pluto-fill'
+            (if plutoFill (hash fill-opacity=0.7) (hash fill-opacity=0))
+          )}}>
           {{input type='checkbox'
             checked=plutoFill}}
           Show Land Use Colors
         </div>
         {{#if plutoFill}}
-        <ul class="layer-key">
-          <li><span style="color:#FEFFA8;">{{fa-icon "square"}}</span>One &amp; Two Family Buildings</li>
-          <li><span style="color:#FCB842;">{{fa-icon "square"}}</span>Multi-Family Walk-Up Buildings</li>
-          <li><span style="color:#B16E00;">{{fa-icon "square"}}</span>Multi-Family Elevator Buildings</li>
-          <li><span style="color:#ff8341;">{{fa-icon "square"}}</span>Mixed Residential &amp; Commercial Buildings</li>
-          <li><span style="color:#fc2929;">{{fa-icon "square"}}</span>Commercial &amp; Office Buildings</li>
-          <li><span style="color:#E362FB;">{{fa-icon "square"}}</span>Industrial &amp; Manufacturing</li>
-          <li><span style="color:#E0BEEB;">{{fa-icon "square"}}</span>Transportation &amp; Utility</li>
-          <li><span style="color:#44A3D5;">{{fa-icon "square"}}</span>Public Facilities &amp; Institutions</li>
-          <li><span style="color:#78D271;">{{fa-icon "square"}}</span>Open Space &amp; Outdoor Recreation</li>
-          <li><span style="color:#BAB8B6;">{{fa-icon "square"}}</span>Parking Facilities</li>
-          <li><span style="color:#555555;">{{fa-icon "square"}}</span>Vacant Land</li>
-          <li><span style="color:#222222;">{{fa-icon "square"}}</span>Other</li>
-        </ul>
+          <ul class="layer-key">
+            <li><span style="color:#FEFFA8;">{{fa-icon "square"}}</span>One &amp; Two Family Buildings</li>
+            <li><span style="color:#FCB842;">{{fa-icon "square"}}</span>Multi-Family Walk-Up Buildings</li>
+            <li><span style="color:#B16E00;">{{fa-icon "square"}}</span>Multi-Family Elevator Buildings</li>
+            <li><span style="color:#ff8341;">{{fa-icon "square"}}</span>Mixed Residential &amp; Commercial Buildings</li>
+            <li><span style="color:#fc2929;">{{fa-icon "square"}}</span>Commercial &amp; Office Buildings</li>
+            <li><span style="color:#E362FB;">{{fa-icon "square"}}</span>Industrial &amp; Manufacturing</li>
+            <li><span style="color:#E0BEEB;">{{fa-icon "square"}}</span>Transportation &amp; Utility</li>
+            <li><span style="color:#44A3D5;">{{fa-icon "square"}}</span>Public Facilities &amp; Institutions</li>
+            <li><span style="color:#78D271;">{{fa-icon "square"}}</span>Open Space &amp; Outdoor Recreation</li>
+            <li><span style="color:#BAB8B6;">{{fa-icon "square"}}</span>Parking Facilities</li>
+            <li><span style="color:#555555;">{{fa-icon "square"}}</span>Vacant Land</li>
+            <li><span style="color:#222222;">{{fa-icon "square"}}</span>Other</li>
+          </ul>
         {{/if}}
       {{/if}}
     {{/layer-menu-item}}


### PR DESCRIPTION
This PR changes the "PLUTO (Tax Lots)" layer palette title to just "Tax Lots" and styles the Land Use colors toggle to look like a part of the Tax Lots layer. See from the before/after below how they used to look like separate items. 

### BEFORE: 
<img src="https://user-images.githubusercontent.com/409279/31194604-adb1c84e-a915-11e7-9956-c29f1d386439.png" width=300 />

### AFTER: 
<img src="https://user-images.githubusercontent.com/409279/31194555-851aefa0-a915-11e7-95a1-3b9c1d231fa1.png" width=300 />

