### PR TITLE
Fewer Palette Accordions

### DIFF
--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -157,18 +157,12 @@
     closed=true
     title='Supporting Zoning Layers'
     as |item|}}
-    {{layer-menu-item
-      for='special-purpose-districts'}}
-    {{layer-menu-item
-      for='special-purpose-subdistricts'}}
-    {{layer-menu-item
-      for='mandatory-inclusionary-housing'}}
-    {{layer-menu-item
-      for='inclusionary-housing'}}
-    {{layer-menu-item
-      for='transit-zones'}}
-    {{layer-menu-item
-      for='fresh'}}
+    {{layer-menu-item for='special-purpose-districts'}}
+    {{layer-menu-item for='special-purpose-subdistricts'}}
+    {{layer-menu-item for='mandatory-inclusionary-housing'}}
+    {{layer-menu-item for='inclusionary-housing'}}
+    {{layer-menu-item for='transit-zones'}}
+    {{layer-menu-item for='fresh'}}
     {{#layer-menu-item for='sidewalkcafes' as |item|}}
       {{#if item.layer.visible}}
         <ul class="layer-key">
@@ -178,14 +172,10 @@
         </ul>
       {{/if}}
     {{/layer-menu-item}}
-    {{layer-menu-item
-      for='low-density-growth-mgmt-areas'}}
-    {{layer-menu-item
-      for='coastal-zone-boundary'}}
-    {{layer-menu-item
-      for='waterfront-access-plan'}}
-    {{layer-menu-item
-      for='historic-districts'}}
+    {{layer-menu-item for='low-density-growth-mgmt-areas'}}
+    {{layer-menu-item for='coastal-zone-boundary'}}
+    {{layer-menu-item for='waterfront-access-plan'}}
+    {{layer-menu-item for='historic-districts'}}
     {{#layer-menu-item for='landmarks' as |item|}}
     {{#if item.layer.visible}}
       <ul class="layer-key">

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -196,44 +196,25 @@
     {{/if}}
     {{/layer-menu-item}}
   {{/layer-palette-accordion}}
-  {{#layer-palette-accordion
-    closed=true
-    title='Transportation'
-  }}
-    {{layer-menu-item
-      for='subway'}}
-  {{/layer-palette-accordion}}
 
   {{#layer-palette-accordion
     closed=true
     title='Administrative Boundaries'}}
-    {{layer-menu-item
-      for='boroughs'}}
-    {{layer-menu-item
-      for='community-districts'}}
-    {{layer-menu-item
-      for='nyccouncildistricts'}}
-    {{layer-menu-item
-      for='nysenatedistricts'}}
-    {{layer-menu-item
-      for='assemblydistricts'}}
-    {{layer-menu-item
-      for='neighborhood-tabulation-areas'}}
+    {{layer-menu-item for='boroughs'}}
+    {{layer-menu-item for='community-districts'}}
+    {{layer-menu-item for='nyccouncildistricts'}}
+    {{layer-menu-item for='nysenatedistricts'}}
+    {{layer-menu-item for='assemblydistricts'}}
+    {{layer-menu-item for='neighborhood-tabulation-areas'}}
   {{/layer-palette-accordion}}
 
   {{#layer-palette-accordion
     closed=true
     title='Basemaps'}}
-    {{layer-menu-item
-      for='aerials-16'}}
-  {{/layer-palette-accordion}}
-  {{#layer-palette-accordion
-    closed=true
-    title='Buildings'}}
-    {{layer-menu-item
-      for='building-footprints'}}
-    {{layer-menu-item
-      for='threed-buildings'}}
+    {{layer-menu-item for='subway'}}
+    {{layer-menu-item for='building-footprints'}}
+    {{layer-menu-item for='threed-buildings'}}
+    {{layer-menu-item for='aerials-16'}}
   {{/layer-palette-accordion}}
 
   <a {{action resetQueryParams}} class="button gray small reset-map-button" disabled={{isDefault}}>


### PR DESCRIPTION
This PR reduces the number of layer palette accordions, in an attempt to group layer groups (🙃) into better categories. Subways were in a group by themselves. As were Aerials. 

These four layer groups are now in one accordion: 
- Subways
- Building Footprints 
- 3D Buildings 
- 2016 Aerials 

Note: I'm not sure "Basemaps" is the right title. Maybe "Basemaps & Extras"