### PR TITLE
Redirect if root/no hash

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -8,8 +8,9 @@ const { service } = Ember.inject;
 export default Ember.Route.extend({
   mainMap: service(),
 
-  beforeModel() {
-    if (!window.location.hash) {
+  beforeModel(transition) {
+    console.log(transition);
+    if (transition.intent.url === '/') {
       this.transitionTo('about');
     }
   },

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -8,6 +8,12 @@ const { service } = Ember.inject;
 export default Ember.Route.extend({
   mainMap: service(),
 
+  beforeModel() {
+    if (!window.location.hash) {
+      this.transitionTo('about');
+    }
+  },
+
   model() {
     const cartoSourcePromises = Object.keys(sources)
       .filter(key => sources[key].type === 'cartovector')


### PR DESCRIPTION
Redirects to about page if no hash is currently in the route. Eventually, a hash is appended, even if there is none in the original route. Closes #225