### PR TITLE
vector 2007 floodplain

### DIFF
--- a/app/layer-groups/effective-flood-insurance-rate-2007.js
+++ b/app/layer-groups/effective-flood-insurance-rate-2007.js
@@ -5,9 +5,25 @@ export default {
   layers: [
     {
       layer: {
-        id: 'effective-flood-insurance-rate-2007-raster',
+        id: 'effective-flood-insurance-rate-2007',
+        type: 'fill',
         source: 'effective-flood-insurance-rate-2007',
-        type: 'raster',
+        'source-layer': 'effective-flood-insurance-rate-2007',
+        paint: {
+          'fill-outline-color': '#cdcdcd',
+          'fill-color': {
+            property: 'fld_zone',
+            type: 'categorical',
+            stops: [
+              ['VE', '#0084a8'],
+              ['AE', '#00a9e6'],
+              ['A', '#00a9e6'],
+              ['AO', '#00a9e6'],
+              ['0.2 PCT ANNUAL CHANCE FLOOD HAZARD', '#00ffc5'],
+            ],
+          },
+          'fill-opacity': 0.7,
+        },
       },
     },
   ],

--- a/app/sources/effective-flood-insurance-rate-2007.js
+++ b/app/sources/effective-flood-insurance-rate-2007.js
@@ -1,6 +1,10 @@
 export default {
   id: 'effective-flood-insurance-rate-2007',
-  type: 'raster',
-  tiles: ['https://tiles2.arcgis.com/tiles/GfwWNkhOj9bNBqoJ/arcgis/rest/services/Effective_Flood_Insurance_Rate_Maps_2007/MapServer/tile/{z}/{y}/{x}'],
-  tileSize: 256,
+  type: 'cartovector',
+  'source-layers': [
+    {
+      id: 'effective-flood-insurance-rate-2007',
+      sql: 'SELECT * FROM firms_100_year_floodplain_2007',
+    },
+  ],
 };

--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -107,7 +107,15 @@
       <li>
         <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/districts-tools/flood-text.page">
           {{fa-icon "external-link"}} Flood Zone
-        </a>
+        </a> <small class="dark-gray">Preliminary Flood Insurance Rate Maps 2015</small>
+      </li>
+    {{/link-to-intersecting}}
+
+    {{#link-to-intersecting table='firms_100_year_floodplain_2007' geometry=model.geometry as |link|}}
+      <li>
+        <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/districts-tools/flood-text.page">
+          {{fa-icon "external-link"}} Flood Zone
+        </a> <small class="dark-gray">Effective Flood Insurance Rate Maps 2007</small>
       </li>
     {{/link-to-intersecting}}
 


### PR DESCRIPTION
This PR swaps the "Effective Flood Insurance Rate Maps 2007" layer's raster tiles for vector and adds it to the list of intersecting supporting layers in the lot view. 