### PR TITLE
Add active style to Mapbox GL Draw button

### DIFF
--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -133,6 +133,10 @@
 }
 
 // Drawing
+.mapbox-gl-draw_ctrl-draw-btn.active {
+  background-color: rgba(0,0,0,0.05);
+}
+
 #measurement-text {
   position: absolute;
   top: 140px;


### PR DESCRIPTION
This PR indicates to the user that they are in drawing mode by changing the color of the draw button. 

However, because clicking the draw button a second time does not cancel drawing mode, there's an [open issue in Mapbox GL Draw](https://github.com/mapbox/mapbox-gl-draw/issues/698) upon which this PR depends.  
