### PR TITLE
Add download links for bookmarked lots

### DIFF
--- a/app/helpers/carto-download-link.js
+++ b/app/helpers/carto-download-link.js
@@ -3,7 +3,7 @@ import { buildSqlUrl } from '../utils/carto';
 
 export function cartoDownloadLink([table, identifier, ids, format]) {
   const query = `SELECT * FROM ${table} WHERE ${identifier} IN (${ids.join(',')})`;
-  return buildSqlUrl(query, format) + `&filename=${table}`;
+  return `${buildSqlUrl(query, format)}&filename=${table}`;
 }
 
 export default Ember.Helper.helper(cartoDownloadLink);

--- a/app/helpers/carto-download-link.js
+++ b/app/helpers/carto-download-link.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import { buildSqlUrl } from '../utils/carto';
+
+export function cartoDownloadLink([table, identifier, ids, format]) {
+  const query = `SELECT * FROM ${table} WHERE ${identifier} IN (${ids.join(',')})`;
+  return buildSqlUrl(query, format) + `&filename=${table}`;
+}
+
+export default Ember.Helper.helper(cartoDownloadLink);

--- a/app/templates/bookmarks.hbs
+++ b/app/templates/bookmarks.hbs
@@ -21,16 +21,14 @@
             </li>
           {{/each}}
         </ul>
-        <a  class="button gray small" 
-            href={{carto-download-link 'support_mappluto' 'bbl' (map-by 'bookmark.id' values) 'csv'}}
-        >
-          Download as CSV
-        </a>
-        <a  class="button gray small" 
-            href={{carto-download-link 'support_mappluto' 'bbl' (map-by 'bookmark.id' values) 'shp'}}
-        >
-          Download as Shapefile
-        </a>
+        <p class="text-small dark-gray" style="padding-left:1.5rem;">
+          <span class="float-left" style="line-height:2;">Download saved Tax Lots (PLUTO) as:&nbsp;</span>
+          <span class="nowrap">
+            <a class="button gray tiny" href={{carto-download-link 'support_mappluto' 'bbl' (map-by 'bookmark.id' values) 'csv'}}>CSV</a>
+            <a class="button gray tiny" href={{carto-download-link 'support_mappluto' 'bbl'
+            (map-by 'bookmark.id' values) 'shp'}}>Shapefile</a>
+          </span>
+        </p>
       {{else if (eq key 'zma')}}
         <h3>Zoning Map Amendments</h3>
         <ul class="no-bullet">

--- a/app/templates/bookmarks.hbs
+++ b/app/templates/bookmarks.hbs
@@ -21,6 +21,16 @@
             </li>
           {{/each}}
         </ul>
+        <a  class="button gray small" 
+            href={{carto-download-link 'support_mappluto' 'bbl' (map-by 'bookmark.id' values) 'csv'}}
+        >
+          Download as CSV
+        </a>
+        <a  class="button gray small" 
+            href={{carto-download-link 'support_mappluto' 'bbl' (map-by 'bookmark.id' values) 'shp'}}
+        >
+          Download as Shapefile
+        </a>
       {{else if (eq key 'zma')}}
         <h3>Zoning Map Amendments</h3>
         <ul class="no-bullet">

--- a/tests/integration/helpers/carto-download-link-test.js
+++ b/tests/integration/helpers/carto-download-link-test.js
@@ -1,0 +1,17 @@
+
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('carto-download-link', 'helper:carto-download-link', {
+  integration: true
+});
+
+// Replace this with your real tests.
+test('it renders', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{carto-download-link inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '1234');
+});
+

--- a/tests/integration/helpers/carto-download-link-test.js
+++ b/tests/integration/helpers/carto-download-link-test.js
@@ -8,10 +8,15 @@ moduleForComponent('carto-download-link', 'helper:carto-download-link', {
 
 // Replace this with your real tests.
 test('it renders', function(assert) {
-  this.set('inputValue', '1234');
+  this.setProperties({
+    table: 'support_mappluto',
+    identifier: 'bbl',
+    ids: [1014970028, 1015280036, 1015280038],
+    format: 'csv',
+  });
 
-  this.render(hbs`{{carto-download-link inputValue}}`);
+  this.render(hbs`{{carto-download-link table identifier ids format}}`);
 
-  assert.equal(this.$().text().trim(), '1234');
+  assert.equal(this.$().text().trim(), 'https://carto.planninglabs.nyc/user/data/api/v2/sql?q=SELECT * FROM support_mappluto WHERE bbl IN (1014970028,1015280036,1015280038)&format=csv&filename=support_mappluto');
 });
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5004319/31854607-f286c184-b669-11e7-88fc-f52e286e4d06.png)


This PR adds 2 buttons to the bookmarks view: download csv and download shp. These buttons download respective formats for bookmarked _lots_, including all their map data.

This PR also includes a new helper: `{{carto-download-link table identifier ids format}}`. 

`cartoDownloadLink([table = 'some table', identifier = 'column name for ids', ids='array of ids', format = 'optional format / file extension'])`