### PR TITLE
Add disclaimer tooltip

### DIFF
--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -52,7 +52,7 @@
 
   <div class="grid-x grid-margin-x">
     <div class="cell medium-shrink">
-      <h6 class="no-margin-">Intersecting Map Layers:</h6>
+      <h6 class="no-margin-">Intersecting Map Layers {{info-tooltip tip="Intersecting layers information is for general use and should be verified for official purposes"}}:</h6>
       <ul class="no-bullet text-small">
         {{#if model.overlay1}}
           <a target="_blank" href="https://www1.nyc.gov/site/planning/zoning/districts-tools/c1-c2-overlays.page" class="">{{fa-icon "external-link"}} Commercial Overlay{{if model.overlay2 's'}}</a> <small class="dark-gray">{{model.overlay1}}</small>{{#if model.overlay2}}, <small class="dark-gray">{{model.overlay2}}</small>{{/if}}


### PR DESCRIPTION
This adds a disclaimer for the intersecting layers section, closing #393. [Language](https://github.com/NYCPlanning/labs-zola/blob/e0260a9e15edbbc8b08a33d3042f7f4c26243cd0/app/templates/lot.hbs#L55) of tooltip should be edited/confirmed before merge.