### PR TITLE
fix manual fitbounds offset

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -66,28 +66,6 @@ export default Ember.Component.extend({
 
   cartoSources: [],
 
-  @computed('mainMap.selected')
-  isSelectedBoundsOptions(selected) {
-    const el = this.$();
-    const height = el.height();
-    const width = el.width();
-
-    const fullWidth = window.innerWidth;
-    // width of content area on large screens is 5/12 of full
-    const contentWidth = (fullWidth / 12) * 5;
-    // on small screens, no offset
-    const offset = fullWidth < 1024 ? 0 : -((width - contentWidth) / 2);
-    const padding = Math.min(height, (width - contentWidth)) / 2.5;
-
-    // get type of selected feature so we can do dynamic padding
-    const type = selected ? selected.constructor.modelName : null;
-
-    return {
-      padding: selected && (type !== 'zoning-district') ? padding : 0,
-      offset: [offset, 0],
-    };
-  },
-
   highlightedLotFeatures: [],
 
   @computed('highlightedLotFeatures')

--- a/app/routes/zoning-district.js
+++ b/app/routes/zoning-district.js
@@ -21,7 +21,8 @@ export default Ember.Route.extend({
     fitBounds() {
       const mainMap = this.get('mainMap');
       const map = mainMap.mapInstance;
-      map.fitBounds(this.get('bounds'));
+      const fitBoundsOptions = mainMap.get('isSelectedBoundsOptions');
+      map.fitBounds(this.get('bounds'), fitBoundsOptions);
     },
   },
 });

--- a/app/services/main-map.js
+++ b/app/services/main-map.js
@@ -41,6 +41,28 @@ export default Ember.Service.extend({
     };
   },
 
+  @computed('selected')
+  isSelectedBoundsOptions(selected) {
+    const el = $('.map-container');
+    const height = el.height();
+    const width = el.width();
+
+    const fullWidth = window.innerWidth;
+    // width of content area on large screens is 5/12 of full
+    const contentWidth = (fullWidth / 12) * 5;
+    // on small screens, no offset
+    const offset = fullWidth < 1024 ? 0 : -((width - contentWidth) / 2);
+    const padding = Math.min(height, (width - contentWidth)) / 2.5;
+
+    // get type of selected feature so we can do dynamic padding
+    const type = selected ? selected.constructor.modelName : null;
+
+    return {
+      padding: selected && (type !== 'zoning-district') ? padding : 0,
+      offset: [offset, 0],
+    };
+  },
+
   resetBounds() {
     const mapInstance = this.get('mapInstance');
     if (mapInstance) {

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -105,7 +105,7 @@
     {{/map.source}}
   {{/if}}
   {{#if shouldFitBounds}}
-    {{map.call 'fitBounds' mainMap.bounds isSelectedBoundsOptions}}
+    {{map.call 'fitBounds' mainMap.bounds mainMap.isSelectedBoundsOptions}}
   {{/if}}
 
   {{#if currentMeasurement}}


### PR DESCRIPTION
This PR fixes the incorrect offset when the user clicks  "Fit map to all XX districts" button in the zoning-district detail view.

It moves the fitBoundsOptions computed property from the `main-map` controller to the `mainMap` service so it can be called from anywhere.

Closes #242