### PR TITLE
simple change to line-width and zoom breaks of co layer

### DIFF
--- a/app/layer-groups/commercial-overlays.js
+++ b/app/layer-groups/commercial-overlays.js
@@ -34,8 +34,14 @@ export default {
         paint: {
           'line-width': {
             stops: [
-              [13, 1],
-              [14, 3],
+              [
+                12,
+                0.1,
+              ],
+              [
+                15,
+                2,
+              ],
             ],
           },
           'line-opacity': 0.75,


### PR DESCRIPTION
This PR adjusts the symbology of the commercial overlays line layer, making it much more subtle on initial load of the app by reducing the line-width when zoomed out.
<img width="517" alt="zola___nyc s_zoning___land_use_map" src="https://user-images.githubusercontent.com/1833820/33159788-8b6a5724-cfe4-11e7-8064-90c4c47dbc2d.png">
