### PR TITLE
Cw opaque 3d buildings

### DIFF
--- a/app/layer-groups/threed-buildings.js
+++ b/app/layer-groups/threed-buildings.js
@@ -33,7 +33,7 @@ export default {
             type: 'identity',
             property: 'min_height',
           },
-          'fill-extrusion-color': 'rgba(172, 172, 179, 1)',
+          'fill-extrusion-color': 'rgba(203, 203, 203, 1)',
           'fill-extrusion-opacity': 0.95,
           'fill-extrusion-translate': [
             3,

--- a/app/layer-groups/threed-buildings.js
+++ b/app/layer-groups/threed-buildings.js
@@ -16,7 +16,14 @@ export default {
         source: 'composite',
         'source-layer': 'building',
         minzoom: 0,
-        filter: ['all', ['==', 'extrude', 'true']],
+        filter: [
+          'all',
+          [
+            '==',
+            'extrude',
+            'true',
+          ],
+        ],
         paint: {
           'fill-extrusion-height': {
             type: 'identity',
@@ -26,12 +33,12 @@ export default {
             type: 'identity',
             property: 'min_height',
           },
-          'fill-extrusion-color': 'rgba(179, 179, 179, 1)',
-          'fill-extrusion-opacity': 0.6,
-          'fill-extrusion-translate': [3, 0],
-        },
-        layout: {
-          visibility: 'visible',
+          'fill-extrusion-color': 'rgba(172, 172, 179, 1)',
+          'fill-extrusion-opacity': 0.95,
+          'fill-extrusion-translate': [
+            3,
+            0,
+          ],
         },
       },
     },

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -14,9 +14,10 @@
   mapLoaded=(action 'handleMapLoad')
   as |map|}}
 
-  {{map.layer-group for='threed-buildings' visible=qps.threed-buildings didToggleVisibility=(action 'adjustBuildingsLayer')}}
 
   {{map.layer-group for='neighborhood-tabulation-areas' visible=qps.neighborhood-tabulation-areas}}
+
+  {{map.layer-group for='threed-buildings' visible=qps.threed-buildings didToggleVisibility=(action 'adjustBuildingsLayer')}}
 
   {{map.layer-group for='assemblydistricts' visible=qps.assemblydistricts}}
 


### PR DESCRIPTION
This PR makes the 3d Buildings layer more opaque, and also changes the rendering order to make sure it appears above tax lots and zoning districts.  It also darkens the color a bit.  The existing layer was too transparent, causing a lot of sloppy overlap of 3d buildings and other rendered features.

<img width="724" alt="zola___nyc s_zoning___land_use_map_ 2" src="https://user-images.githubusercontent.com/1833820/33160183-15c6c1c0-cfe8-11e7-8290-7e5858bff332.png">
