### PR TITLE
Fix url hash override bug

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -40,6 +40,8 @@ const draw = new MapboxDraw({
   styles: drawStyles,
 });
 
+
+
 export default Ember.Component.extend({
   mainMap: service(),
   mapMouseover: service(),
@@ -47,9 +49,13 @@ export default Ember.Component.extend({
 
   classNames: ['map-container'],
 
-  lat: 40.7071266,
-  lng: -74,
-  zoom: 10.2,
+  lat: 40.7125,
+  @computed('mainMap.isSelectedBoundsOptions')
+  lng(boundsOptions) {
+    console.log(boundsOptions)
+    return boundsOptions.offset[0] === 0 ? -73.9022 : -73.733;
+  },
+  zoom: 9.72,
   menuTo: 'layers-menu',
 
   layerGroups,

--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -40,8 +40,6 @@ const draw = new MapboxDraw({
   styles: drawStyles,
 });
 
-
-
 export default Ember.Component.extend({
   mainMap: service(),
   mapMouseover: service(),
@@ -52,7 +50,6 @@ export default Ember.Component.extend({
   lat: 40.7125,
   @computed('mainMap.isSelectedBoundsOptions')
   lng(boundsOptions) {
-    console.log(boundsOptions)
     return boundsOptions.offset[0] === 0 ? -73.9022 : -73.733;
   },
   zoom: 9.72,

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -10,7 +10,8 @@ export default Ember.Route.extend({
   mainMap: service(),
 
   beforeModel(transition) {
-    if (transition.intent.url === '/') {
+    // only transition to about if index is loaded and there is no hash
+    if (transition.intent.url === '/' && window.location.href.split('#').length < 2) {
       this.transitionTo('about');
     }
   },

--- a/app/services/main-map.js
+++ b/app/services/main-map.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import pointLayer from '../layers/point-layer';
 import { computed } from 'ember-decorators/object'; // eslint-disable-line
 
-const DEFAULT_BOUNDS = [-74.077644, 40.690913, -73.832692, 40.856654];
+const DEFAULT_BOUNDS = [-73.9, 40.690913, -73.832692, 40.856654];
 
 export default Ember.Service.extend({
   mapInstance: null,
@@ -12,7 +12,7 @@ export default Ember.Service.extend({
   currentZoom: null,
   currentMeasurement: null,
   isDrawing: false,
-  shouldFitBounds: true,
+  shouldFitBounds: false,
 
   @computed('selected')
   bounds(selected) {


### PR DESCRIPTION
This PR addresses the bug where the initial URL hash was being overridden because the app wanted to fitBounds when it first loads.  (Fitbounds on first load was necessary because half of the map is covered by the information pane on large screens, but the full map shows on small screens.

Fixes:
- The initial longitude of the maps center is now a computed property and is based on the same logic that handles the fitBoundsOptions for both conditions of the map.  
- Somewhat related, this PR adds logic to only show the "About" pane if the initial URL has no location hash.  (This effectively shows it on first load, but ensures that a saved URL with a hash actually has the same view when opened as the user who shared it saw.

Closes #423