### PR TITLE
Hidable Sibling UI

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -272,3 +272,33 @@ button {
 .ember-tooltip {
   font-size: rem-calc(10);
 }
+
+
+//
+// Hide Adjacent Sibling UI
+// --------------------------------------------------
+.hidable-sibling-toggle {
+  color: $primary-color;
+
+  &.top-right {
+    position: absolute;
+    top: 0;
+    right: 0;
+    margin: 0;
+  }
+}
+
+.checkbox-hide-sibling {
+  display: none;
+
+  &:checked {
+
+    + .hidable-sibling-toggle {
+      transform: rotate(180deg);
+    }
+
+    & ~ .hidable-sibling {
+      display: none;
+    }
+  }
+}

--- a/app/styles/modules/_m-layer-palette.scss
+++ b/app/styles/modules/_m-layer-palette.scss
@@ -106,6 +106,7 @@ $layer-palette-hover-color: rgba($dark-gray,0.08);
 
   > li {
     margin-bottom: $layer-palette-padding;
+    position: relative;
   }
 
   label {

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -55,7 +55,11 @@
                   refs=(array 'qps.C1' 'qps.C2' 'qps.C3' 'qps.C4' 'qps.C5' 'qps.C6' 'qps.C7' 'qps.C8')
                   values=(array qps.C1 qps.C2 qps.C3 qps.C4 qps.C5 qps.C6 qps.C7 qps.C8)
                   scope=qps}}Commercial Districts <span style="background-color:#ff0000;" class="icon polygon legend-icon"></span></label>
-                <ul class="nested columns-3">
+
+                <input id="nested-commercial" class="checkbox-hide-sibling" type="checkbox" checked>
+                <label for="nested-commercial" class="hidable-sibling-toggle top-right">{{fa-icon 'angle-up'}}</label>
+
+                <ul class="nested columns-3 hidable-sibling">
                   <li><label>{{multiSelect.checkbox value='C1' checked=qps.C1}}C1</label></li>
                   <li><label>{{multiSelect.checkbox value='C2' checked=qps.C2}}C2</label></li>
                   <li><label>{{multiSelect.checkbox value='C3' checked=qps.C3}}C3</label></li>
@@ -71,7 +75,11 @@
                   refs=(array 'qps.M1' 'qps.M2' 'qps.M3')
                   values=(array qps.M1 qps.M2 qps.M3)
                   scope=qps}}Manufacturing Districts <span style="background-color:#e362fb;" class="icon polygon legend-icon"></span></label>
-                <ul class="nested columns-3">
+
+                <input id="nested-manufacturing" class="checkbox-hide-sibling" type="checkbox" checked>
+                <label for="nested-manufacturing" class="hidable-sibling-toggle top-right">{{fa-icon 'angle-up'}}</label>
+
+                <ul class="nested columns-3 hidable-sibling">
                   <li><label>{{multiSelect.checkbox value='M1' checked=qps.M1}}M1</label></li>
                   <li><label>{{multiSelect.checkbox value='M2' checked=qps.M2}}M2</label></li>
                   <li><label>{{multiSelect.checkbox value='M3' checked=qps.M3}}M3</label></li>
@@ -82,7 +90,11 @@
                   refs=(array 'qps.R1' 'qps.R2' 'qps.R3' 'qps.R4' 'qps.R5' 'qps.R6' 'qps.R7' 'qps.R8' 'qps.R9' 'qps.R10')
                   values=(array qps.R1 qps.R2 qps.R3 qps.R4 qps.R5 qps.R6 qps.R7 qps.R8 qps.R9 qps.R10)
                   scope=qps}}Residential Districts  <span style="background-color:#f2f618;" class="icon polygon legend-icon"></span></label>
-                <ul class="nested columns-3">
+
+                <input id="nested-residential" class="checkbox-hide-sibling" type="checkbox" checked>
+                <label for="nested-residential" class="hidable-sibling-toggle top-right">{{fa-icon 'angle-up'}}</label>
+
+                <ul class="nested columns-3 hidable-sibling">
                   <li><label>{{multiSelect.checkbox value='R1' checked=qps.R1}}R1</label></li>
                   <li><label>{{multiSelect.checkbox value='R2' checked=qps.R2}}R2</label></li>
                   <li><label>{{multiSelect.checkbox value='R3' checked=qps.R3}}R3</label></li>
@@ -116,8 +128,12 @@
                 <label>{{group-checkbox
                   refs=(array 'qps.c11' 'qps.c12' 'qps.c13' 'qps.c14' 'qps.c15')
                   values=(array qps.c11 qps.c12 qps.c13 qps.c14 qps.c15)
-                  scope=qps}}Select All C1</label>
-                <ul class="nested columns-2">
+                  scope=qps}}C1-1 through C1-5</label>
+
+                <input id="nested-c1" class="checkbox-hide-sibling" type="checkbox" checked>
+                <label for="nested-c1" class="hidable-sibling-toggle top-right">{{fa-icon 'angle-up'}}</label>
+
+                <ul class="nested columns-2 hidable-sibling">
                   <li><label>{{multiSelect.checkbox value='C1-1' checked=qps.c11}}C1-1</label></li>
                   <li><label>{{multiSelect.checkbox value='C1-2' checked=qps.c12}}C1-2</label></li>
                   <li><label>{{multiSelect.checkbox value='C1-3' checked=qps.c13}}C1-3</label></li>
@@ -129,8 +145,12 @@
                 <label>{{group-checkbox
                   refs=(array 'qps.c21' 'qps.c22' 'qps.c23' 'qps.c24' 'qps.c25')
                   values=(array qps.c21 qps.c22 qps.c23 qps.c24 qps.c25)
-                  scope=qps}}Select All C2</label>
-                <ul class="nested columns-2">
+                  scope=qps}}C2-1 through C2-5</label>
+
+                <input id="nested-c2" class="checkbox-hide-sibling" type="checkbox" checked>
+                <label for="nested-c2" class="hidable-sibling-toggle top-right">{{fa-icon 'angle-up'}}</label>
+
+                <ul class="nested columns-2 hidable-sibling">
                   <li><label>{{multiSelect.checkbox value='C2-1' checked=qps.c21}}C2-1</label></li>
                   <li><label>{{multiSelect.checkbox value='C2-2' checked=qps.c22}}C2-2</label></li>
                   <li><label>{{multiSelect.checkbox value='C2-3' checked=qps.c23}}C2-3</label></li>


### PR DESCRIPTION
This PR closes #346 by… 
- Creates a `.hidable-sibling-toggle` with a checkbox that controls the display of `.hidable-sibling`
- Adds this to Zoning Districts and Commercial Overlays in the layer palette 