### PR TITLE
Add /bbl route

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -10,6 +10,7 @@ const Router = Ember.Router.extend(trackPage, {
 Router.map(function () { // eslint-disable-line
   this.route('lot', { path: 'lot/:boro/:block/:lot' });
   this.route('zma', { path: 'zma/:ulurpno' });
+  this.route('bbl', { path: 'bbl/:bbl' });
   this.route('zoning-district', { path: 'zoning-district/:zonedist' });
   this.route('special-purpose-district', { path: 'special-purpose-district/:id' });
   this.route('special-purpose-subdistricts', { path: 'special-purpose-subdistrict/:id' });

--- a/app/routes/bbl.js
+++ b/app/routes/bbl.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import bblDemux from '../utils/bbl-demux';
+
+export default Ember.Route.extend({
+  model(params) {
+    const bbl = bblDemux(params.bbl);
+    this.transitionTo('lot', bbl.boro, bbl.block, bbl.lot);
+  },
+});

--- a/tests/acceptance/visit-lot-test.js
+++ b/tests/acceptance/visit-lot-test.js
@@ -10,3 +10,12 @@ test('visiting a lot', function(assert) {
     assert.notEqual(find('.content-area').text().length, 0);
   });
 });
+
+test('visiting a bbl', function(assert) {
+  visit('/bbl/1001870021');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/lot/1/187/21');
+    assert.notEqual(find('.content-area').text().length, 0);
+  });
+});

--- a/tests/unit/routes/bbl-test.js
+++ b/tests/unit/routes/bbl-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:bbl', 'Unit | Route | bbl', {
+  // Specify the other units that are required for this test.
+  needs: ['service:metrics'],
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
Simple commit that adds a `/bbl` route. Uses already implemented `bbl-demux` to parse bbl and redirect to `/lot` route.

Unit and acceptance tests included.