### PR TITLE
remove commercial overlays from intersecting layers section

### DIFF
--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -50,13 +50,13 @@
 
       {{#if model.overlay1}}
         <li>
-          {{link-to-intersecting model.overlay1 'commercial-overlays' 'support_zoning_co' model.geometry responseIdentifier='overlay' classNames="button"}}
+          {{link-to-intersecting model.overlay1 'commercial-overlay' 'support_zoning_co' model.geometry responseIdentifier='overlay' classNames="button"}}
         </li>
       {{/if}}
 
       {{#if model.overlay2}}
         <li>
-          {{link-to-intersecting model.overlay2 'commercial-overlays' 'support_zoning_co' model.geometry responseIdentifier='overlay' classNames="button"}}
+          {{link-to-intersecting model.overlay2 'commercial-overlay' 'support_zoning_co' model.geometry responseIdentifier='overlay' classNames="button"}}
         </li>
       {{/if}}
     </ul>
@@ -66,9 +66,6 @@
     <div class="cell medium-shrink">
       <h6 class="no-margin-">Intersecting Map Layers {{info-tooltip tip="These intersections should be independently verified and should not be relied upon to determine the zoning rules applicable to a property."}}:</h6>
       <ul class="no-bullet text-small">
-        {{#if model.overlay1}}
-          <a target="_blank" href="https://www1.nyc.gov/site/planning/zoning/districts-tools/c1-c2-overlays.page" class="">{{fa-icon "external-link"}} Commercial Overlay{{if model.overlay2 's'}}</a> <small class="dark-gray">{{model.overlay1}}</small>{{#if model.overlay2}}, <small class="dark-gray">{{model.overlay2}}</small>{{/if}}
-        {{/if}}
         {{#if model.histdist}}<li><a target="_blank" href="http://www1.nyc.gov/site/lpc/about/landmark-designation.page">{{fa-icon "external-link"}} Historic District</a> <small class="dark-gray">{{model.histdist}}</small></li>{{/if}}
 
         {{#intersecting-layers
@@ -147,7 +144,7 @@
             </li>
           {{/if}}
 
-          {{#unless (or numberIntersecting model.histdist model.overlay1)}}
+          {{#unless (or numberIntersecting model.histdist)}}
             None found
           {{/unless}}
 


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR restores commercial overlays to the "Zoning District" section of the lot profile, and removes them from the "intersecting layers" section.

Closes #458