### PR TITLE
workaround for flyTo bug on search result click

### DIFF
--- a/app/components/map-search.js
+++ b/app/components/map-search.js
@@ -112,6 +112,7 @@ export default Ember.Component.extend({
     goTo(result) {
       const mainMap = this.get('mainMap');
       const mapInstance = mainMap.get('mapInstance');
+      const { type } = result;
 
       this.$('.map-search-input').blur();
       // clear address marker
@@ -122,23 +123,23 @@ export default Ember.Component.extend({
         focused: false,
       });
 
-      if (result.type === 'lot') {
+      if (type === 'lot') {
         const { boro, block, lot } = bblDemux(result.bbl);
         this.set('searchTerms', result.bbl);
         this.transitionTo('lot', boro, block, lot);
       }
 
-      if (result.type === 'zma') {
+      if (type === 'zma') {
         this.set('searchTerms', result.label);
         this.transitionTo('zma', result.ulurpno);
       }
 
-      if (result.type === 'zoning-district') {
+      if (type === 'zoning-district') {
         mainMap.set('shouldFitBounds', true);
         this.transitionTo('zoning-district', result.label);
       }
 
-      if (result.type === 'neighborhood') {
+      if (type === 'neighborhood') {
         this.set('searchTerms', result.neighbourhood);
         const center = result.coordinates;
         mapInstance.flyTo({
@@ -147,13 +148,12 @@ export default Ember.Component.extend({
         });
       }
 
-      if (result.type === 'address') {
+      if (type === 'address') {
         const center = result.coordinates;
         mainMap.set('currentAddress', center);
 
         this.set('searchTerms', result.label);
         this.saveAddress({ address: result.label, coordinates: result.coordinates });
-        this.transitionTo('index');
 
         if (mapInstance) {
           mapInstance.flyTo({
@@ -161,14 +161,16 @@ export default Ember.Component.extend({
             zoom: 15,
           });
         }
+
+        mapInstance.once('moveend', () => { this.transitionTo('index'); });
       }
 
-      if (result.type === 'special-purpose-district') {
+      if (type === 'special-purpose-district') {
         this.set('searchTerms', result.sdname);
         this.transitionTo('special-purpose-district', result.cartodb_id);
       }
 
-      if (result.type === 'commercial-overlay') {
+      if (type === 'commercial-overlay') {
         this.set('searchTerms', result.label);
         this.transitionTo('commercial-overlay', result.overlay);
       }

--- a/app/components/map-search.js
+++ b/app/components/map-search.js
@@ -160,9 +160,8 @@ export default Ember.Component.extend({
             center,
             zoom: 15,
           });
+          mapInstance.once('moveend', () => { this.transitionTo('index'); });
         }
-
-        mapInstance.once('moveend', () => { this.transitionTo('index'); });
       }
 
       if (type === 'special-purpose-district') {


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds a workaround fix for the bug in #447 where clicking address search results when on a non-index route does not fly the map to the search result.

This fix delays the route change until after the `flyTo()` is complete.


Closes #447, but it's just a workaround and leaves a clumsy UI where the content pane remains visible until after the flyTo animation.  #474 was created as a new bug to get this working correctly in the future.
