### PR TITLE
505 zoning map links

### DIFF
--- a/app/controllers/lot.js
+++ b/app/controllers/lot.js
@@ -3,4 +3,9 @@ import { computed } from 'ember-decorators/object'; // eslint-disable-line
 import Bookmarkable from '../mixins/bookmarkable';
 
 export default Ember.Controller.extend(Bookmarkable, {
+
+  @computed('lot.zonemap')
+  paddedZonemap(zonemap) {
+    return (`0${zonemap}`).slice(-3);
+  },
 });

--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -163,7 +163,7 @@
         <ul class="no-bullet text-small">
           {{#if lot.bbl}}<li><a target="_blank" href="http://maps.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName={{lot.bbl}}">{{fa-icon "external-link"}} Digital Tax Map</a></li>{{/if}}
           {{#if lot.zonemap}}<li><a target="_blank" href="http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map{{lot.zonemap}}.pdf">{{fa-icon "external-link"}} Zoning Map <small>(PDF)</small></a></li>{{/if}}
-          {{#if lot.zonemap}}<li><a target="_blank" href="http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/historical-zoning-maps/maps{{lot.zonemap}}.pdf">{{fa-icon "external-link"}} Historical Zoning Maps <small>(PDF)</small></a></li>{{/if}}
+          {{#if lot.zonemap}}<li><a target="_blank" href="http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/historical-zoning-maps/maps{{paddedZonemap}}.pdf">{{fa-icon "external-link"}} Historical Zoning Maps <small>(PDF)</small></a></li>{{/if}}
         </ul>
       </div>
     </div>


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds a computed variable to zero-pad 1-digit zoning map names, only for building the historical zoning map links.

Closes #505
