### PR TITLE
Fix missing map on landscape iPad

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -121,6 +121,12 @@ body.index {
   }
 }
 
+.navigation-area {
+  @include breakpoint(large) {
+    height: 100%;
+  }
+}
+
 .content-area {
   position: relative;
   z-index: 2;
@@ -191,8 +197,8 @@ body.index {
 }
 
 .cyclomedia {
-  width: 100%; 
-  height:300px; 
+  width: 100%;
+  height:300px;
   border: 0;
 }
 
@@ -210,4 +216,3 @@ body.index {
     left: 50%;
   }
 }
-


### PR DESCRIPTION
This PR was an attempt at #454. 
It does not close the issue, but resolves part of it. 
- Does: fix the missing map on iOS landscape devices
- Does not: fix the hidden `.close-button` on Safari

I've investigated and documented the close button bug in the issue. As it's a failing of Safari to follow the CSS spec, I'm not sure how to resolve it without changing the design. I may have to move the button out of its parent `.content-area` element, which'll require quite a few changes to the layout CSS.  Let's get this map fix in tho. 