### PR TITLE
Fix close button for Safari

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -144,18 +144,27 @@ body.index {
     position: absolute;
     right: 0;
   }
+}
+
+.content-close-button-container {
+  position: relative;
+  z-index: 3;
+  box-shadow: 0 -2px 0 rgba(0,0,0,0.1);
+  background-color: $white;
+  text-align: right;
+
+  @include breakpoint(medium down) {
+    @include xy-cell-static(full,false,0);
+  }
 
   & > .close-button {
     position: relative;
-    top: -1rem;
-    right: -0.5rem;
-    float: right;
-    margin: 0.5rem;
+    margin: 0;
 
     @include breakpoint(large) {
       display: block;
       position: fixed;
-      z-index: 2;
+      z-index: 3;
       top: 6.5rem;
       right: 41.66667%;
       background-color: $white;
@@ -168,7 +177,6 @@ body.index {
     }
   }
 }
-
 
 .content-is-closed {
 

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -1,5 +1,6 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-  {{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}
 
   <h1 class="header-xlarge">Welcome to New York&nbsp;City's zoning &amp; land&nbsp;use&nbsp;map.</h1>
 

--- a/app/templates/bookmarks.hbs
+++ b/app/templates/bookmarks.hbs
@@ -1,5 +1,6 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4 bookmarks">
-  {{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}
 
   {{#if (await bookmarksSettled)}}
     {{#each-in (group-by 'recordType.content' model) as |key values|}}

--- a/app/templates/commercial-overlay.hbs
+++ b/app/templates/commercial-overlay.hbs
@@ -1,5 +1,7 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-  {{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}
+
   {{#if model.isRunning}}
     {{#content-placeholders as |placeholder|}}
       {{placeholder.text lines=1}}
@@ -16,7 +18,7 @@
     </h1>
 
     <p>A commercial overlay is a C1 or C2 district mapped within residential districts to serve local retail needs (grocery stores, dry cleaners, restaurants, for example). Commercial overlay districts, designated by the letters C1-1 through C1-5 and C2-1 through C2-5, are shown on the zoning maps as a pattern superimposed on a residential district.</p>
-    
+
     <p>Unless otherwise specified on the zoning maps, the depth of C1 overlay districts, measured from the nearest street, is 200 feet for C1-1 districts, 150 feet for C1-2, C1-3, C2-1, C2-2 and C2-3 districts, and 100 feet for C1-4, C1-5, C2-4 and C2-5 districts. When mapped on the long dimension of a block, commercial overlays extend to the midpoint of that block.</p>
     <p><a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/c1-c2-overlays.page" target="_blank">Learn More</a></p>
     <button {{action "fitBounds"}} class="button tiny hollow">Fit map to all {{overlay.id}} districts</button>

--- a/app/templates/data.hbs
+++ b/app/templates/data.hbs
@@ -1,5 +1,6 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-  {{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}
 
   <h1>Data Sources</h1>
 

--- a/app/templates/features.hbs
+++ b/app/templates/features.hbs
@@ -1,5 +1,6 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4 text-center medium-text-left">
-  {{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}
 
   <h1>Features</h1>
 

--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -1,7 +1,7 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-  {{#link-to 'index' classNames='close-button'}}
-    <span aria-hidden="true">&times;</span>
-  {{/link-to}}
+
   {{#if model.isRunning}}
     {{#content-placeholders as |placeholder|}}
       {{placeholder.text lines=1}}
@@ -30,7 +30,7 @@
         {{#if lot.zonedist2}}<li><a target="_blank" href="https://www1.nyc.gov/site/planning/zoning/districts-tools/{{primaryzone2}}.page" class="button">{{fa-icon 'external-link'}} {{lot.zonedist2}}</a></li>{{/if}}
         {{#if lot.zonedist3}}<li><a target="_blank" href="https://www1.nyc.gov/site/planning/zoning/districts-tools/{{primaryzone3}}.page" class="button">{{fa-icon 'external-link'}} {{lot.zonedist3}}</a></li>{{/if}}
         {{#if lot.zonedist4}}<li><a target="_blank" href="https://www1.nyc.gov/site/planning/zoning/districts-tools/{{primaryzone4}}.page" class="button">{{fa-icon 'external-link'}} {{lot.zonedist4}}</a></li>{{/if}}
-        
+
         {{#each (await parentSpecialPurposeDistricts) as |specialDistrict|}}
               <li><a target="_blank" href="https://www1.nyc.gov/site/planning/zoning/districts-tools/special-purpose-districts-{{specialDistrict.boroName}}.page#{{specialDistrict.anchorName}}" class="button">{{fa-icon 'external-link'}} {{specialDistrict.label}}</a></li>
         {{/each}}

--- a/app/templates/special-purpose-district.hbs
+++ b/app/templates/special-purpose-district.hbs
@@ -1,5 +1,6 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-  {{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}
 
   {{#if model.isRunning}}
     {{#content-placeholders as |placeholder|}}

--- a/app/templates/special-purpose-subdistricts.hbs
+++ b/app/templates/special-purpose-subdistricts.hbs
@@ -1,5 +1,6 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-  {{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}
 
   {{#if model.isRunning}}
     {{#content-placeholders as |placeholder|}}

--- a/app/templates/zma.hbs
+++ b/app/templates/zma.hbs
@@ -1,5 +1,7 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-  {{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}
+
   {{#if model.isRunning}}
     {{#content-placeholders as |placeholder|}}
       {{placeholder.text lines=1}}
@@ -20,4 +22,5 @@
     <div class="data-grid"><label class="data-label">Land Use Application / CPC&nbsp;Report</label><span class="datum"><a target="_blank" href="http://a030-lucats.nyc.gov/lucats/DirectAccess.aspx?ULURPNO={{zma.lucats}}">{{fa-icon "external-link"}} {{zma.lucats}} <small>(LUCATS)</small></a></span></div>
     <div class="data-grid"><label class="data-label">Zoning Sketch Map</label><span class="datum"><a target="_blank" href="http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/sketchmaps/skz{{zma.id}}.pdf">{{fa-icon "file-pdf-o"}} {{zma.id}} <small>(PDF)</small></a></span></div>
   {{/if}}
+
 </div>

--- a/app/templates/zoning-district.hbs
+++ b/app/templates/zoning-district.hbs
@@ -1,5 +1,7 @@
+<div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
+
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-  {{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}
+
   <label class="header-type">ZONING DISTRICT</label>
   <h1 class="header-large">{{model.id}}</h1>
   <p>{{model.description}}</p>
@@ -9,5 +11,7 @@
   {{else}}
     <p><a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/special-purpose-districts-manhattan.page#battery_park" target="_blank">{{fa-icon "external-link"}} Learn more about the Special Battery Park City District&hellip;</a></p>
   {{/unless}}
+
 </div>
+
 {{outlet}}


### PR DESCRIPTION
This PR moves the `.close-button` outside of the `.content-area`, since Safari (wrongly) doesn't allow fixed-positioned children to ignore their parent's `overflow:hidden`. This has the downside of adding a bit of whitespace at the top of the content area on smaller screens. 

Closes #454. 