### PR TITLE
Set a default land use color so "Other" isn't so prominent

### DIFF
--- a/app/layer-groups/pluto.js
+++ b/app/layer-groups/pluto.js
@@ -33,6 +33,7 @@ export default {
               ['10', '#BAB8B6'],
               ['11', '#555555'],
             ],
+            default: '#EEEEEE',
           },
           'fill-opacity': 0,
         },

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -35,7 +35,7 @@
             <li><span style="color:#78D271;">{{fa-icon "square"}}</span>Open Space &amp; Outdoor Recreation</li>
             <li><span style="color:#BAB8B6;">{{fa-icon "square"}}</span>Parking Facilities</li>
             <li><span style="color:#555555;">{{fa-icon "square"}}</span>Vacant Land</li>
-            <li><span style="color:#222222;">{{fa-icon "square"}}</span>Other</li>
+            <li><span style="color:#E7E7E7;">{{fa-icon "square"}}</span>Other</li>
           </ul>
         {{/if}}
       {{/if}}
@@ -267,11 +267,11 @@
       {{/if}}
     {{/layer-menu-item}}
 
-    <div 
-      class="layer-menu-item" 
+    <div
+      class="layer-menu-item"
       {{action 'switchAerial' 16 true}}
     >
-      {{switch-toggle 
+      {{switch-toggle
         checked=(or qps.aerials-16 qps.aerials-1924 qps.aerials-1951 qps.aerials-1996)}}
       Aerials
     </div>


### PR DESCRIPTION
This PR adds a `default` parameter to the `fill-color` on the `pluto-fill` layer. This gives the "Other" land use a specific color, instead of defaulting to the stock Mapbox style (black). 

### Before: 
![image](https://user-images.githubusercontent.com/409279/37789104-6eedf8fa-2dd9-11e8-8de6-e69de67f8b7c.png)

### After: 
![image](https://user-images.githubusercontent.com/409279/37789116-778048e2-2dd9-11e8-8805-5acb64f411b5.png)
