### PR TITLE
add zap link for ulurp number

### DIFF
--- a/app/templates/zma.hbs
+++ b/app/templates/zma.hbs
@@ -16,10 +16,9 @@
     <label class="header-label">ZONING MAP AMENDMENT</label>
     <h1 class="header-large">{{zma.project_na}}</h1>
 
-    <div class="data-grid"><label class="data-label">ULURP Number</label><span class="datum">{{zma.id}}</span></div>
+    <div class="data-grid"><label class="data-label">ULURP Number</label><span class="datum"><a target="_blank" href="https://zap-api.planninglabs.nyc/projects/ulurp/{{zma.lucats}}">{{fa-icon "external-link"}} {{zma.id}}</a></span></div>
     <div class="data-grid"><label class="data-label">Effective</label><span class="datum">{{zma.effectiveDisplay}}</span></div>
     <div class="data-grid"><label class="data-label">Status</label><span class="datum">{{zma.status}}</span></div>
-    <div class="data-grid"><label class="data-label">Land Use Application / CPC&nbsp;Report</label><span class="datum"><a target="_blank" href="http://a030-lucats.nyc.gov/lucats/DirectAccess.aspx?ULURPNO={{zma.lucats}}">{{fa-icon "external-link"}} {{zma.lucats}} <small>(LUCATS)</small></a></span></div>
     <div class="data-grid"><label class="data-label">Zoning Sketch Map</label><span class="datum"><a target="_blank" href="http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/sketchmaps/skz{{zma.id}}.pdf">{{fa-icon "file-pdf-o"}} {{zma.id}} <small>(PDF)</small></a></span></div>
   {{/if}}
 


### PR DESCRIPTION
-Turns ulurp number on zoning map amendment route into a link that goes to the new zap frontend.  (Depends on this PR to be deployed: https://github.com/NYCPlanning/labs-zap-api/pull/48)

- Removes the existing lucats link from the zoning map amendment route

Closes #578 