### PR TITLE
Improve BBL Form UI

### DIFF
--- a/app/components/bbl-lookup.js
+++ b/app/components/bbl-lookup.js
@@ -42,8 +42,13 @@ export default Component.extend({
       });
     },
 
+    resetErrorMessage() {
+      this.set('errorMessage', '');
+    },
+
     setBorocode(option) {
       this.set('boro', option);
+      this.set('errorMessage', '');
     },
   },
 });

--- a/app/templates/components/bbl-lookup.hbs
+++ b/app/templates/components/bbl-lookup.hbs
@@ -8,7 +8,7 @@
 </span>
 
 {{#unless closed}}
-<div class="bbl-lookup-form">
+<form class="bbl-lookup-form" {{action 'checkBBL' on='submit'}}>
   <div class="bbl-power-select">
     <label>Borough</label>
     {{#power-select options=boroOptions searchEnabled=false selected=boro searchField='name' onchange=(action 'setBorocode') as |boro|}}
@@ -18,18 +18,18 @@
   <div class="grid-x">
     <div class="cell auto block-container">
       <label>Block
-        {{input type='number' value=block}}
+        {{input type='number' value=block key-press=(action 'resetErrorMessage')}}
       </label>
     </div>
     <div class="cell auto lot-container">
       <label>Lot
-        {{input type='number' value=lot}}
+        {{input type='number' value=lot key-press=(action 'resetErrorMessage')}}
       </label>
     </div>
   </div>
   {{#if errorMessage}}<p class="lu-red text-center text-small"><{{errorMessage}}</p>{{/if}}
   <input type="submit" value="Go to BBL" class="button small expanded no-margin" onclick={{action 'checkBBL'}}>
-</div>
+</form>
 {{/unless}}
 
 {{yield}}


### PR DESCRIPTION
This PR closes #574 by…
- Changing the `div` to a `form` so that pressing enter in an input triggers the submit action
- Adds actions to the inputs so that changing them resets the error message to `''` 
