### PR TITLE
580 incorrect intersection

### DIFF
--- a/app/components/intersecting-layers.js
+++ b/app/components/intersecting-layers.js
@@ -8,7 +8,7 @@ import carto from '../utils/carto';
 const generateSQL = function(table, bbl) {
   // special handling for tables where we don't want to SELECT *
   let intersectionTable = table;
-  if (table === 'effective-flood-insurance-rate-2007') {
+  if (table === 'floodplain_firm2007_v0') {
     intersectionTable = `(
       SELECT the_geom
       FROM floodplain_firm2007_v0
@@ -44,6 +44,7 @@ export default Component.extend({
       hash[table] = carto.SQL(generateSQL(table, bbl))
         .then((response => get(response[0] || {}, responseIdentifier)));
     });
+
 
     return yield RSVP.hash(hash);
   }).restartable(),

--- a/app/controllers/lot.js
+++ b/app/controllers/lot.js
@@ -21,7 +21,7 @@ export default Controller.extend(Bookmarkable, {
     return (`0${zonemap}`).slice(-3);
   },
 
-  @computed('lot.geometry')
+  @computed('model.value.geometry')
   parentSpecialPurposeDistricts(geometry) {
     return carto.SQL(SQL('special_purpose_districts_v201806', geometry))
       .then(response => response.map(

--- a/app/templates/components/intersecting-layers.hbs
+++ b/app/templates/components/intersecting-layers.hbs
@@ -1,5 +1,5 @@
-{{#if (await intersectingLayers) as |layers|}}
-  {{yield layers numberIntersecting}}
+{{#if (not intersectingLayers.isRunning)}}
+  {{yield intersectingLayers.value numberIntersecting}}
 {{else}}
   <div class="sk-circle">
     <div class="sk-circle1 sk-child"></div>

--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -58,9 +58,20 @@
           {{#if model.value.histdist}}<li><a target="_blank" href="http://www1.nyc.gov/site/lpc/about/landmark-designation.page">{{fa-icon "external-link"}} Historic District</a> <small class="dark-gray">{{model.value.histdist}}</small></li>{{/if}}
 
           {{#intersecting-layers
-              tables=(array 'inclusionary_housing_v201804' 'transitzones_v201607' 'fresh_zones_v201611' 'waterfront_access_plan_v201109' 'coastal_zone_boundary_v201601' 'lower_density_growth_management_areas_v201709' 'floodplain_pfirm2015_v0' 'floodplain_firm2007_v0' 'mandatory_inclusionary_housing_v20180628' 'e_designations_v20180628' 'appendixj_designated_mdistricts_v201712')
+              tables=(array
+                'inclusionary_housing_v201804'
+                'transitzones_v201607'
+                'fresh_zones_v201611'
+                'waterfront_access_plan_v201109'
+                'coastal_zone_boundary_v201601'
+                'lower_density_growth_management_areas_v201709'
+                'floodplain_firm2007_v0'
+                'floodplain_pfirm2015_v0'
+                'mandatory_inclusionary_housing_v20180628'
+                'e_designations_v20180628'
+                'appendixj_designated_mdistricts_v201712'
+              )
               bbl=model.value.bbl as |layers numberIntersecting|}}
-
             {{#if layers.inclusionary_housing_v201804}}
               <li>
                 <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/districts-tools/inclusionary-housing.page">


### PR DESCRIPTION
Changes Proposed:
- Restore intersecting features list, which was not showing due to an incorrectly handled task.  Closes #630
- Fix improperly-named floodplain table intersections, confirm that 2007 and 2015 flood plain intersecting layers correspond with what is being symbolized on the map.  Closes #580
- Spot checked intersecting layers throughout the city, unable to find a situation where intersecting layers does not match what is symbolized on the map. Closes #354
- Restore Special Purpose District Intersection, which was getting a bad response from carto due to composing a SQL query with an undefined geometry.  Closes #629

