### PR TITLE
disable map interactivity when in draw mode

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -138,6 +138,11 @@ export default Component.extend({
     };
   },
 
+  @computed('mainMap.drawMode')
+  interactivity(drawMode) {
+    return !drawMode;
+  },
+
   selectedFillLayer,
   selectedLineLayer,
 

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -14,6 +14,7 @@
 
   {{#map.labs-layers
     layerGroups=layerGroups
+    interactivity=interactivity
     highlightedFeatureLayer=highlightedLotLayer
     onLayerClick=(action 'handleLayerClick')
     onLayerHighlight=(action 'handleLayerHighlight')

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.1.0",
     "ember-local-storage": "^1.4.0",
-    "ember-mapbox-composer": "0.0.5",
+    "ember-mapbox-composer": "0.0.6",
     "ember-mapbox-gl": "^0.10.0",
     "ember-mapbox-gl-draw": "^1.0.1",
     "ember-maybe-import-regenerator": "^0.1.6",


### PR DESCRIPTION
_Do not merge until ember-mapbox-composer has been upgraded to 0.0.6_ via https://github.com/NYCPlanning/ember-mapbox-composer/pull/8

Adds `interactivity` property to labs-layers component, based on drawMode.  Fixes the bug where things were highlighting and the map was responding to clicks during drawing mode. 

