### PR TITLE
Remove mustache; lazy load some turf assets

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -1,7 +1,5 @@
 import Component from '@ember/component';
 import mapboxgl from 'mapbox-gl';
-import area from '@turf/area';
-import lineDistance from '@turf/line-distance';
 import numeral from 'numeral';
 import EmberObject from '@ember/object';
 
@@ -311,7 +309,7 @@ class MainMap extends Component {
   }
 
   @action
-  handleMeasurement() {
+  async handleMeasurement() {
     this.set('drawDidRender', true);
     const draw = this.get('draw');
     // should log both metric and standard display strings for the current drawn feature
@@ -320,6 +318,11 @@ class MainMap extends Component {
     if (features.length > 0) {
       const feature = features[0];
       // metric calculation
+
+      // lazy load these deps
+      const { default: area } = await import('@turf/area');
+      const { default: lineDistance } = await import('@turf/line-distance');
+
       const drawnLength = (lineDistance(feature) * 1000); // meters
       const drawnArea = area(feature); // square meters
 

--- a/app/components/tooltip-renderer.js
+++ b/app/components/tooltip-renderer.js
@@ -1,17 +1,25 @@
 import Component from '@ember/component';
-import { computed } from '@ember-decorators/object';
-import mustache from 'mustache';
+import { argument } from '@ember-decorators/argument';
+import { defineProperty, computed as computedProperty } from '@ember/object';
+import Ember from 'ember';
 
 export default class TooltipRenderer extends Component {
-  @computed('feature', 'template')
-  get renderedText() {
-    const properties = this.get('feature.properties');
-    const template = this.get('template');
+  init(...args) {
+    super.init(...args);
 
-    return mustache.render(template, properties);
+    this.setProperties(this.get('feature.properties'));
+
+    defineProperty(this, 'layout', computedProperty(() => {
+      const template = this.get('template');
+      const { properties } = this.get('feature');
+
+      return Ember.HTMLBars.compile(template, properties);
+    }));
   }
 
-  feature;
+  @argument
+  feature = {}
 
+  @argument
   template = ''
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -36,6 +36,8 @@ module.exports = (defaults) => {
     },
   });
 
+  app.import('vendor/ember/ember-template-compiler.js');
+
   // Use `app.import` to add additional libraries to the generated
   // output files.
   //

--- a/package.json
+++ b/package.json
@@ -91,16 +91,15 @@
     "mapbox-gl": "^0.44.0",
     "mapbox-gl-draw": "0.16.0",
     "moment": "2.22.2",
-    "qunit-dom": "^0.8.0"
+    "qunit-dom": "^0.8.0",
+    "@turf/area": "^6.0.1",
+    "@turf/line-distance": "^4.7.3"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"
   },
   "dependencies": {
-    "@turf/area": "^6.0.1",
     "@turf/bbox": "^6.0.1",
-    "@turf/line-distance": "^4.7.3",
-    "mustache": "^2.3.2",
     "numeral": "^2.0.6"
   }
 }


### PR DESCRIPTION
Removes mustache and uses ember's internal templating; lazy loads turf assets except bbox