### PR TITLE
680 init map to lot

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -50,7 +50,7 @@ class MainMap extends Component {
 
   lat = 40.7125;
 
-  @computed('mainMap.isSelectedBoundsOptions')
+  @computed()
   get lng() {
     const boundsOptions = this.get('mainMap.isSelectedBoundsOptions');
     return boundsOptions.offset[0] === 0 ? -73.9022 : -73.733;

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -176,7 +176,6 @@ export default Controller.extend(mapQueryParams.Mixin, {
           }
 
           if (zonedist) {
-            mainMap.set('shouldFitBounds', false);
             this.transitionToRoute('zoning-district', zonedist);
           }
 
@@ -189,7 +188,6 @@ export default Controller.extend(mapQueryParams.Mixin, {
           }
 
           if (overlay) {
-            mainMap.set('shouldFitBounds', false);
             this.transitionToRoute('commercial-overlay', overlay);
           }
 
@@ -225,7 +223,6 @@ export default Controller.extend(mapQueryParams.Mixin, {
       }
 
       if (type === 'zoning-district') {
-        mainMap.set('shouldFitBounds', true);
         this.transitionToRoute('zoning-district', result.label);
       }
 

--- a/app/controllers/zoning-district.js
+++ b/app/controllers/zoning-district.js
@@ -3,8 +3,8 @@ import { computed as computedProp } from '@ember/object';
 import { computed } from '@ember-decorators/object'; // eslint-disable-line
 
 export default Controller.extend({
-  primaryzoneURL: computedProp('model.primaryzone', function() {
-    const primaryzone = this.get('model.primaryzone');
+  primaryzoneURL: computedProp('model.value.primaryzone', function() {
+    const primaryzone = this.get('model.value.primaryzone');
     let url = '';
 
     if ((primaryzone === 'c1') || (primaryzone === 'c2')) {

--- a/app/mixins/update-selection.js
+++ b/app/mixins/update-selection.js
@@ -1,13 +1,32 @@
 import Mixin from '@ember/object/mixin';
-import { task } from 'ember-concurrency';
+import { task, waitForProperty } from 'ember-concurrency';
+import { inject as service } from '@ember/service';
 
 export default Mixin.create({
+  mainMap: service(),
   afterModel({ taskInstance }) {
     this.setSelectedTask.perform(taskInstance);
+  },
+
+  setupController(controller, { taskInstance }) {
+    this.waitToFitBounds.perform(taskInstance);
+    this._super(controller, taskInstance);
   },
 
   setSelectedTask: task(function* (taskInstance) {
     const model = yield taskInstance;
     this.set('mainMap.selected', model);
   }).restartable().cancelOn('deactivate'),
+
+  waitToFitBounds: task(function* (taskInstance) {
+    yield waitForProperty(taskInstance, 'state', 'finished');
+
+    this.get('mainMap.setBounds').perform();
+  }).restartable(),
+
+  actions: {
+    didTransition() {
+      this.get('mainMap.setBounds').perform();
+    },
+  },
 });

--- a/app/models/commercial-overlay.js
+++ b/app/models/commercial-overlay.js
@@ -1,12 +1,14 @@
-import DS from 'ember-data';
 import { computed } from '@ember-decorators/object';
+import { attr } from '@ember-decorators/data';
 import bbox from '@turf/bbox';
 import Bookmarkable from './bookmark';
 
 export default class MyComponent extends Bookmarkable {
-  geometry = DS.attr();
+  @attr()
+  geometry;
 
-  overlay = DS.attr('string');
+  @attr('string')
+  overlay;
 
   @computed('geometry')
   get bounds() {

--- a/app/models/special-purpose-district.js
+++ b/app/models/special-purpose-district.js
@@ -1,14 +1,17 @@
-import DS from 'ember-data';
+import { attr } from '@ember-decorators/data';
 import { computed } from '@ember-decorators/object'; // eslint-disable-line
 import bbox from '@turf/bbox';
 import Bookmarkable from './bookmark';
 
 export default class MyComponent extends Bookmarkable {
-  geometry = DS.attr();
+  @attr()
+  geometry;
 
-  sdlbl = DS.attr('string');
+  @attr('string')
+  sdlbl;
 
-  sdname = DS.attr('string');
+  @attr('string')
+  sdname;
 
   @computed('geometry')
   get bounds() {

--- a/app/models/special-purpose-subdistrict.js
+++ b/app/models/special-purpose-subdistrict.js
@@ -1,14 +1,17 @@
-import DS from 'ember-data';
+import { attr } from '@ember-decorators/data';
 import { computed } from '@ember-decorators/object'; // eslint-disable-line
 import bbox from '@turf/bbox';
 import Bookmarkable from './bookmark';
 
 export default class MyComponent extends Bookmarkable {
-  geometry = DS.attr();
+  @attr()
+  geometry;
 
-  splbl = DS.attr('string');
+  @attr('string')
+  splbl;
 
-  spname = DS.attr('string');
+  @attr('string')
+  spname;
 
   @computed('geometry')
   get bounds() {

--- a/app/models/zoning-district.js
+++ b/app/models/zoning-district.js
@@ -116,7 +116,7 @@ export default class ZoningDistrict extends DS.Model {
 
   @computed('geometry')
   get bounds() {
-    const geometry = this.get('geometry)');
+    const geometry = this.get('geometry');
     return bbox(geometry);
   }
 }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,10 +4,14 @@ import { inject as service } from '@ember/service';
 export default Route.extend({
   mainMap: service(),
 
-  beforeModel(transition) {
+  beforeModel({ targetName }) {
     // only transition to about if index is loaded and there is no hash
-    if (transition.intent.url === '/' && window.location.href.split('#').length < 2) {
+    if (targetName === 'index') {
       this.transitionTo('about');
+    }
+
+    if (targetName === 'lot') {
+      this.set('mainMap.routeIntentIsNested', true);
     }
   },
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -23,7 +23,7 @@ export default Route.extend({
         { id: 'commercial-overlays', visible: true },
         { id: 'zoning-map-amendments', visible: false },
         { id: 'zoning-map-amendments-pending', visible: false },
-        { id: 'special-purpose-districts', visible: false },
+        { id: 'special-purpose-districts', visible: false, layers: [{}, { clickable: true, highlightable: true }] },
         { id: 'special-purpose-subdistricts', visible: false },
         { id: 'limited-height-districts', visible: false },
         { id: 'mandatory-inclusionary-housing', visible: false },

--- a/app/routes/bookmarks.js
+++ b/app/routes/bookmarks.js
@@ -7,14 +7,4 @@ export default Route.extend({
   model() {
     return this.store.findAll('bookmark');
   },
-
-  actions: {
-    didTransition() {
-      this.mainMap
-        .setProperties({
-          selected: null,
-          shouldFitBounds: false,
-        });
-    },
-  },
 });

--- a/app/routes/commercial-overlay.js
+++ b/app/routes/commercial-overlay.js
@@ -13,10 +13,6 @@ export default Route.extend(updateSelectionMixin, {
 
   bounds: alias('mainMap.bounds'),
 
-  setupController(controller, { taskInstance }) {
-    this._super(controller, taskInstance);
-  },
-
   actions: {
     fitBounds() {
       const { mainMap } = this;

--- a/app/routes/lot.js
+++ b/app/routes/lot.js
@@ -1,7 +1,5 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { task, waitForProperty } from 'ember-concurrency';
-import { next } from '@ember/runloop';
 import bblDemux from '../utils/bbl-demux';
 import updateSelectionMixin from '../mixins/update-selection';
 
@@ -14,17 +12,4 @@ export default Route.extend(updateSelectionMixin, {
       taskInstance: this.store.findRecord('lot', id),
     };
   },
-
-  setupController(controller, { taskInstance }) {
-    this.waitToFitBounds.perform(taskInstance);
-    this._super(controller, taskInstance);
-  },
-
-  waitToFitBounds: task(function* (taskInstance) {
-    yield waitForProperty(taskInstance, 'state', 'finished');
-
-    next(() => {
-      this.set('mainMap.shouldFitBounds', true);
-    });
-  }).restartable(),
 });

--- a/app/routes/special-purpose-district.js
+++ b/app/routes/special-purpose-district.js
@@ -13,10 +13,4 @@ export default Route.extend(updateSelectionMixin, {
   setupController(controller, { taskInstance }) {
     this._super(controller, taskInstance);
   },
-
-  actions: {
-    didTransition() {
-      this.set('mainMap.shouldFitBounds', true);
-    },
-  },
 });

--- a/app/routes/special-purpose-district.js
+++ b/app/routes/special-purpose-district.js
@@ -9,8 +9,4 @@ export default Route.extend(updateSelectionMixin, {
       taskInstance: this.store.findRecord('special-purpose-district', params.id),
     };
   },
-
-  setupController(controller, { taskInstance }) {
-    this._super(controller, taskInstance);
-  },
 });

--- a/app/routes/special-purpose-subdistricts.js
+++ b/app/routes/special-purpose-subdistricts.js
@@ -9,14 +9,4 @@ export default Route.extend(updateSelectionMixin, {
       taskInstance: this.store.findRecord('special-purpose-subdistrict', params.id),
     };
   },
-
-  setupController(controller, { taskInstance }) {
-    this._super(controller, taskInstance);
-  },
-
-  actions: {
-    didTransition() {
-      this.set('mainMap.shouldFitBounds', true);
-    },
-  },
 });

--- a/app/routes/zma.js
+++ b/app/routes/zma.js
@@ -10,14 +10,4 @@ export default Route.extend(updateSelectionMixin, {
       taskInstance: this.store.findRecord('zma', params.ulurpno),
     };
   },
-
-  setupController(controller, { taskInstance }) {
-    this._super(controller, taskInstance);
-  },
-
-  actions: {
-    didTransition() {
-      this.set('mainMap.shouldFitBounds', true);
-    },
-  },
 });

--- a/app/routes/zoning-district.js
+++ b/app/routes/zoning-district.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-import { alias } from '@ember/object/computed';
 import { computed, action } from '@ember-decorators/object'; // eslint-disable-line
 import updateSelectionMixin from '../mixins/update-selection';
 
@@ -12,13 +11,11 @@ export default class ZoningDistrictRoute extends mappableRoute {
     };
   }
 
-  bounds = alias('mainMap.bounds');
-
   @action
   fitBounds() {
     const { mainMap } = this;
     const map = mainMap.mapInstance;
     const fitBoundsOptions = mainMap.get('isSelectedBoundsOptions');
-    map.fitBounds(this.bounds, fitBoundsOptions);
+    map.fitBounds(this.mainMap.bounds, fitBoundsOptions);
   }
 }

--- a/app/routes/zoning-district.js
+++ b/app/routes/zoning-district.js
@@ -1,17 +1,15 @@
 import Route from '@ember/routing/route';
 import { alias } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
 import { computed, action } from '@ember-decorators/object'; // eslint-disable-line
+import updateSelectionMixin from '../mixins/update-selection';
 
-export default class ZoningDistrictRoute extends Route {
-  mainMap = service();
+const mappableRoute = Route.extend(updateSelectionMixin, {});
 
+export default class ZoningDistrictRoute extends mappableRoute {
   model(params) {
-    return this.store.findRecord('zoning-district', params.zonedist);
-  }
-
-  afterModel(model) {
-    this.set('mainMap.selected', model);
+    return {
+      taskInstance: this.store.findRecord('zoning-district', params.zonedist),
+    };
   }
 
   bounds = alias('mainMap.bounds');

--- a/app/services/main-map.js
+++ b/app/services/main-map.js
@@ -37,6 +37,8 @@ export default class MainMapService extends Service {
 
   drawnFeature = null;
 
+  routeIntentIsNested = false;
+
   @computed('drawnFeature')
   get drawnFeatureSource() {
     const feature = this.get('drawnFeature');
@@ -64,6 +66,7 @@ export default class MainMapService extends Service {
     const el = document.querySelector('.map-container');
     const height = el.offsetHeight;
     const width = el.offsetWidth;
+    const routeIntentIsNested = this.get('routeIntentIsNested');
 
     const fullWidth = window.innerWidth;
     // width of content area on large screens is 5/12 of full
@@ -75,10 +78,13 @@ export default class MainMapService extends Service {
     // get type of selected feature so we can do dynamic padding
     const type = selected ? selected.constructor.modelName : null;
 
-    return {
+    const options = {
+      ...(routeIntentIsNested ? { duration: 0 } : {}),
       padding: selected && (type !== 'zoning-district') && (type !== 'commercial-overlay') ? padding : 0,
       offset: [offset, 0],
     };
+
+    return options;
   }
 
   resetBounds() {

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -53,10 +53,6 @@
     {{/map.source}}
   {{/if}}
 
-  {{#if shouldFitBounds}}
-    {{map.call 'fitBounds' mainMap.bounds mainMap.isSelectedBoundsOptions}}
-  {{/if}}
-
   {{map.on 'click' (action routeToLot)}}
   {{map.on 'data' (action 'mapLoading')}}
   {{map.on 'zoomend' (action 'handleZoomend')}}

--- a/app/templates/special-purpose-subdistricts.hbs
+++ b/app/templates/special-purpose-subdistricts.hbs
@@ -15,7 +15,7 @@
       createBookmark=(action 'createBookmark')}}
 
     <label class="header-label clearfix">
-      Special Purpose Subdistrict <span class="medium-gray">|</span> {{model.value.sdlbl}}
+      Special Purpose Subdistrict <span class="medium-gray">|</span> {{model.value.splbl}}
     </label>
 
     <h1 class="content-header">

--- a/app/templates/zoning-district.hbs
+++ b/app/templates/zoning-district.hbs
@@ -1,13 +1,13 @@
 <div class="content-close-button-container">{{#link-to 'index' classNames='close-button'}}<span aria-hidden="true">&times;</span>{{/link-to}}</div>
 
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-
+  {{log model}}
   <label class="header-type">ZONING DISTRICT</label>
-  <h1 class="header-large">{{model.id}}</h1>
-  <p>{{model.description}}</p>
-  {{#unless (eq model.id 'BPC')}}
-    <p><a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/{{primaryzoneURL}}.page" target="_blank">{{fa-icon 'external-link-alt'}} Learn more about {{model.id}} districts&hellip;</a></p>
-    <button {{action "fitBounds"}} class="button tiny hollow">Fit map to all {{model.id}} districts</button>
+  <h1 class="header-large">{{model.value.id}}</h1>
+  <p>{{model.value.description}}</p>
+  {{#unless (eq model.value.id 'BPC')}}
+    <p><a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/{{primaryzoneURL}}.page" target="_blank">{{fa-icon 'external-link-alt'}} Learn more about {{model.value.id}} districts&hellip;</a></p>
+    <button {{action "fitBounds"}} class="button tiny hollow">Fit map to all {{model.value.id}} districts</button>
   {{else}}
     <p><a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/special-purpose-districts-manhattan.page#battery_park" target="_blank">{{fa-icon 'external-link-alt'}} Learn more about the Special Battery Park City District&hellip;</a></p>
   {{/unless}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,7 +16,7 @@ module.exports = (defaults) => {
       },
     },
     babel: {
-      plugins: [babelPlugin],
+      plugins: [babelPlugin, 'transform-object-rest-spread'],
     },
     autoImport: {
       webpack: {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@turf/line-distance": "^4.7.3",
     "babel-eslint": "^8.0.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
+    "babel-plugin-transform-object-rest-spread": "6.26.0",
     "broccoli-asset-rev": "^2.7.0",
     "broccoli-clean-css": "^2.0.1",
     "ember-async-await-helper": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli": "~3.5.0",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^6.16.0",
-    "ember-cli-bundle-analyzer": "0.0.3",
+    "ember-cli-bundle-analyzer": "0.0.4",
     "ember-cli-concat": "1.3.0",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-eslint": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,6 +1798,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -2002,6 +2006,13 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,15 +2455,15 @@ broccoli-clean-css@^2.0.1:
     json-stable-stringify "^1.0.1"
     source-map-to-comment "^1.1.0"
 
-broccoli-concat-analyser@^4.3.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/broccoli-concat-analyser/-/broccoli-concat-analyser-4.3.1.tgz#1b4481ab34481c00ba022ea9faa1c9036d47dab3"
+broccoli-concat-analyser@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/broccoli-concat-analyser/-/broccoli-concat-analyser-4.3.2.tgz#e3b3234fedd0c0876e6c6e65422d62186b2450b9"
   dependencies:
     filesize "^3.3.0"
     fs-extra "^4.0.2"
     ora "^0.3.0"
     pify "^4.0.0"
-    uglify-es "^3.0.23"
+    terser "^3.10.11"
     walk-sync "^0.3.1"
     workerpool "^2.3.1"
     zlib "^1.0.5"
@@ -4211,11 +4211,11 @@ ember-cli-broccoli-sane-watcher@^2.1.1:
     rsvp "^3.0.18"
     sane "^2.4.1"
 
-ember-cli-bundle-analyzer@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-bundle-analyzer/-/ember-cli-bundle-analyzer-0.0.3.tgz#b30181bcc96c1d78d0e59069026d4bcfbe1eeb7d"
+ember-cli-bundle-analyzer@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-bundle-analyzer/-/ember-cli-bundle-analyzer-0.0.4.tgz#92651be05600f89e7bab1ee54b81935dbbfffedf"
   dependencies:
-    broccoli-concat-analyser "^4.3.0"
+    broccoli-concat-analyser "^4.3.2"
     debug "^3.1.0"
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.1.2"
@@ -11287,6 +11287,14 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
+terser@^3.10.11:
+  version "3.10.11"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-3.10.11.tgz#e063da74b194dde9faf0a561f3a438c549d2da3f"
+  dependencies:
+    commander "~2.17.1"
+    source-map "~0.6.1"
+    source-map-support "~0.5.6"
+
 terser@^3.7.5:
   version "3.10.2"
   resolved "https://registry.yarnpkg.com/terser/-/terser-3.10.2.tgz#a61d2c97065f9fdc8c49a18655e2a80ca7298a94"
@@ -11550,7 +11558,7 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
 
-uglify-es@^3.0.23, uglify-es@^3.3.4:
+uglify-es@^3.3.4:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
   dependencies:


### PR DESCRIPTION
This PR closes #680 by eliminating the `fitBounds` animation when the routing intent is something other than application, about, or index, reducing the average lot profile view size to around 2mb (down from 6mb). 

This PR also refactors the way fitBounds is handled. Instead of an awkward template-based approach, we explicitly call `fitBounds` from the map instance. We handle asynchrony by using tasks that wait for the mapInstance to be available. 

Please pay special attention to these routes:
- [ ] lot
- [ ] zma
- [ ] bbl
- [ ] zoning-district
- [ ] special-purpose-district
- [ ] special-purpose-subdistricts
- [ ] commercial-overlay

Manual test them by:

1. Turning on their respective layer if needed.
2. Navigating to that layer by clicking on it from the map.
3. Checking that there's no missing content (telltale signs include lone `|`s, templates with only generic text).
4. Reload the route and make sure that it fits the map to the bounds of the resources. Lot route should _not_ animate, others do. 
5. Zoom around on the map, then, if present, click the button "zoom this all [resourceName]". This button is sometimes visible at the bottom of the profile view.


