### PR TITLE
Integrate mapbox composer upgrade

### DIFF
--- a/app/components/layer-palette.js
+++ b/app/components/layer-palette.js
@@ -1,16 +1,25 @@
 import Component from '@ember/component';
 import { action } from '@ember-decorators/object';
+import { argument } from '@ember-decorators/argument';
 
 const aerialYears = [16, 1996, 1951, 1924];
 
 export default class LayerPaletteComponent extends Component {
+  @argument
+  qps = null;
+
+  @argument
+  layerGroups;
+
+  @argument
+  resetQueryParmas;
+
   classNames = ['layer-palette hide-for-print'];
 
   closed = true;
 
   plutoFill = false;
 
-  qps = null;
 
   aerialYears = aerialYears;
 

--- a/app/components/tooltip-renderer.js
+++ b/app/components/tooltip-renderer.js
@@ -11,9 +11,8 @@ export default class TooltipRenderer extends Component {
 
     defineProperty(this, 'layout', computedProperty(() => {
       const template = this.get('template');
-      const { properties } = this.get('feature');
 
-      return Ember.HTMLBars.compile(template, properties);
+      return Ember.HTMLBars.compile(template);
     }));
   }
 

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -5,6 +5,7 @@ import EmberObject, { set, computed as computedProp } from '@ember/object';
 import { inject as service } from '@ember/service';
 import QueryParams from 'ember-parachute';
 import { computed } from '@ember-decorators/object'; // eslint-disable-line
+import { alias } from '@ember/object/computed';
 import bblDemux from '../utils/bbl-demux';
 
 import Geometric from '../mixins/geometric';
@@ -61,9 +62,10 @@ export const mapQueryParams = new QueryParams(
       'aerials-1996': { defaultValue: false },
       'aerials-1951': { defaultValue: false },
 
-      'layer-groups': {
+      layerGroups: {
         defaultValue: [],
         refresh: true,
+        as: 'layer-groups',
       },
     },
   ),
@@ -80,28 +82,8 @@ export default Controller.extend(mapQueryParams.Mixin, {
     this.set('qps', proxy);
   },
 
-  'layer-groups': computedProp('model.layerGroups.@each.visible', {
-    get() {
-      const { model } = this;
-
-      if (model) {
-        return model.layerGroups.filterBy('visible').mapBy('id').sort();
-      }
-
-      return [];
-    },
-    set(key, value) {
-      if (Array.isArray(value) && this.model && value.length) {
-        this.model.layerGroups.forEach((layerGroup) => {
-          if (value.includes(layerGroup.id)) {
-            layerGroup.set('visible', true);
-          } else {
-            layerGroup.set('visible', false);
-          }
-        });
-      }
-    },
-  }),
+  layerGroupService: service('layerGroups'),
+  layerGroups: alias('layerGroupService.visibleLayerGroups'),
 
   mainMap: service(),
   metrics: service(),

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   mainMap: service(),
+  layerGroupService: service('layerGroups'),
 
   beforeModel({ targetName }) {
     // only transition to about if index is loaded and there is no hash
@@ -102,8 +103,8 @@ export default Route.extend({
   },
 
   setupController(controller, model) {
-    const { defaultVisibleLayerGroups } = model;
-    controller.setDefaultQueryParamValue('layer-groups', defaultVisibleLayerGroups);
+    const { layerGroups } = model;
+    this.get('layerGroupService').initializeObservers(layerGroups, controller);
 
     this._super(controller, model);
   },

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -82,26 +82,6 @@ export default Route.extend({
     };
   },
 
-  afterModel(
-    { layerGroups, defaultVisibleLayerGroups },
-    { queryParams: { 'layer-groups': layerGroupParams = '[]' } },
-  ) {
-    this.mainMap.resetBounds();
-    const params = JSON.parse(layerGroupParams).sort();
-
-    if (!defaultVisibleLayerGroups.every(layerGroup => params.includes(layerGroup))
-      && params.length) {
-      // set initial state from query params when not default
-      layerGroups.forEach((layerGroup) => {
-        if (params.includes(layerGroup.id)) {
-          layerGroup.set('visible', true);
-        } else {
-          layerGroup.set('visible', false);
-        }
-      });
-    }
-  },
-
   setupController(controller, model) {
     const { layerGroups } = model;
     this.get('layerGroupService').initializeObservers(layerGroups, controller);

--- a/app/templates/components/tooltip-renderer.hbs
+++ b/app/templates/components/tooltip-renderer.hbs
@@ -1,1 +1,3 @@
-{{renderedText}}
+{{#if template}}
+  {{renderedText}}
+{{/if}}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-in-viewport": "^3.1.3",
     "ember-load-initializers": "^1.1.0",
     "ember-local-storage": "^1.4.0",
-    "ember-mapbox-composer": "NYCPlanning/ember-mapbox-composer#refactor-highlighted-source",
+    "ember-mapbox-composer": "0.0.21",
     "ember-mapbox-gl": "0.12.0",
     "ember-mapbox-gl-draw": "2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-in-viewport": "^3.1.3",
     "ember-load-initializers": "^1.1.0",
     "ember-local-storage": "^1.4.0",
-    "ember-mapbox-composer": "0.0.18",
+    "ember-mapbox-composer": "NYCPlanning/ember-mapbox-composer#refactor-highlighted-source",
     "ember-mapbox-gl": "0.12.0",
     "ember-mapbox-gl-draw": "2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,7 +933,7 @@
     vfile "^2.3.0"
     vfile-reporter "^4.0.0"
 
-"@mapbox/jsonlint-lines-primitives@^2.0.1", "@mapbox/jsonlint-lines-primitives@^2.0.2":
+"@mapbox/jsonlint-lines-primitives@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
 
@@ -1013,6 +1013,12 @@
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-4.7.3.tgz#bc312ac43cab3c532a483151c4c382c5649429e9"
 
+"@turf/invariant@6.x":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.1.2.tgz#6013ed6219f9ac2edada9b31e1dfa5918eb0a2f7"
+  dependencies:
+    "@turf/helpers" "6.x"
+
 "@turf/invariant@^4.7.3":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-4.7.3.tgz#538f367d23c113fc849d70c9a524b8563874601d"
@@ -1034,6 +1040,14 @@
 "@turf/meta@^4.7.3":
   version "4.7.4"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-4.7.4.tgz#6de2f1e9890b8f64b669e4b47c09b20893063977"
+
+"@turf/union@^6.0.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@turf/union/-/union-6.0.3.tgz#463b62d71c406f40a6978f560bfb92e88fe7db56"
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    martinez-polygon-clipping "^0.4.3"
 
 "@types/acorn@^4.0.3":
   version "4.0.3"
@@ -4117,6 +4131,36 @@ ember-auto-import@1.2.13, ember-auto-import@^1.2.13:
     walk-sync "^0.3.2"
     webpack "^4.12.0"
 
+ember-auto-import@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.2.5.tgz#0ae1027613b9b9c92f64d237e84ac05f023a1e67"
+  dependencies:
+    babel-core "^6.26.3"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.26.0"
+    babylon "^6.18.0"
+    broccoli-concat "^3.2.2"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-plugin "^1.3.0"
+    broccoli-source "^1.1.0"
+    debug "^3.1.0"
+    ember-cli-babel "^6.6.0"
+    enhanced-resolve "^4.0.0"
+    fs-extra "^6.0.1"
+    fs-tree-diff "^0.5.7"
+    handlebars "^4.0.11"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    pkg-up "^2.0.0"
+    quick-temp "^0.1.8"
+    resolve "^1.7.1"
+    rimraf "^2.6.2"
+    symlink-or-copy "^1.2.0"
+    walk-sync "^0.3.2"
+    webpack "^4.12.0"
+
 ember-basic-dropdown@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-1.0.3.tgz#bd785c84ea2b366951e0630f173c84677ed53b6c"
@@ -4845,13 +4889,14 @@ ember-local-storage@^1.4.0:
     ember-cli-version-checker "^2.1.0"
     ember-copy "^1.0.0"
 
-ember-mapbox-composer@0.0.18:
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.0.18.tgz#0e5d4ca68205ddae0b0650473141822c2c6a58f9"
+ember-mapbox-composer@NYCPlanning/ember-mapbox-composer#refactor-highlighted-source:
+  version "0.0.19"
+  resolved "https://codeload.github.com/NYCPlanning/ember-mapbox-composer/tar.gz/72a7d2cef521c673dec7ecdc5182f22d00be1895"
   dependencies:
-    "@ember-decorators/argument" "0.8.15"
     "@ember-decorators/babel-transforms" "^2.0.0"
+    "@turf/union" "^6.0.0"
     cartobox-promises-utility "1.0.2"
+    ember-auto-import "1.2.5"
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^2.0.1"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
@@ -4859,9 +4904,7 @@ ember-mapbox-composer@0.0.18:
     ember-decorators "2.1.0"
     ember-fetch "5.1.3"
     ember-font-awesome "^4.0.0-rc.2"
-    ember-mapbox-gl "0.12.0"
     ember-truth-helpers "2.0.0"
-    mapbox-gl "0.47.0"
     pretender "2.0.0"
 
 ember-mapbox-gl-draw@2.0.0:
@@ -6259,7 +6302,7 @@ geojson-rewind@^0.3.0:
     minimist "1.2.0"
     sharkdown "^0.1.0"
 
-geojson-vt@^3.1.4, geojson-vt@^3.2.0:
+geojson-vt@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"
 
@@ -6476,15 +6519,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-
-gray-matter@^3.0.8:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-3.1.1.tgz#101f80d9e69eeca6765cdce437705b18f40876ac"
-  dependencies:
-    extend-shallow "^2.0.1"
-    js-yaml "^3.10.0"
-    kind-of "^5.0.2"
-    strip-bom-string "^1.0.0"
 
 grid-index@^1.0.0:
   version "1.0.0"
@@ -7321,7 +7355,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@3.x.x, js-yaml@^3.10.0, js-yaml@^3.12.0, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.9.1:
+js-yaml@3.x.x, js-yaml@^3.12.0, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -7450,7 +7484,7 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
-kind-of@^5.0.0, kind-of@^5.0.2:
+kind-of@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
 
@@ -8126,37 +8160,6 @@ mapbox-gl-draw@0.16.0:
     point-geometry "0.0.0"
     xtend "^4.0.1"
 
-mapbox-gl@0.47.0:
-  version "0.47.0"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.47.0.tgz#c72f1d3462037f0bb5b8dc25cc8a029513f2b7cd"
-  dependencies:
-    "@mapbox/jsonlint-lines-primitives" "^2.0.1"
-    "@mapbox/mapbox-gl-supported" "^1.4.0"
-    "@mapbox/point-geometry" "^0.1.0"
-    "@mapbox/shelf-pack" "^3.1.0"
-    "@mapbox/tiny-sdf" "^1.1.0"
-    "@mapbox/unitbezier" "^0.0.0"
-    "@mapbox/vector-tile" "^1.3.1"
-    "@mapbox/whoots-js" "^3.0.0"
-    brfs "^1.4.4"
-    csscolorparser "~1.0.2"
-    earcut "^2.1.3"
-    geojson-rewind "^0.3.0"
-    geojson-vt "^3.1.4"
-    gl-matrix "^2.6.1"
-    gray-matter "^3.0.8"
-    grid-index "^1.0.0"
-    minimist "0.0.8"
-    pbf "^3.0.5"
-    quickselect "^1.0.0"
-    rw "^1.3.3"
-    shuffle-seed "^1.1.6"
-    sort-object "^0.3.2"
-    supercluster "^4.0.1"
-    through2 "^2.0.3"
-    tinyqueue "^1.1.0"
-    vt-pbf "^3.0.1"
-
 mapbox-gl@0.50.0:
   version "0.50.0"
   resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.50.0.tgz#49f44149f02fdd25ab64a2ec4efc7a11a5c96f55"
@@ -8233,6 +8236,13 @@ markdown-it@^8.3.1, markdown-it@^8.4.2:
     linkify-it "^2.0.0"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
+
+martinez-polygon-clipping@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz#a3971ddf1da147104b5d0fbbf68f728bb62885c1"
+  dependencies:
+    splaytree "^0.1.4"
+    tinyqueue "^1.2.0"
 
 matcher-collection@^1.0.0, matcher-collection@^1.0.4, matcher-collection@^1.0.5:
   version "1.0.5"
@@ -10539,10 +10549,6 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
-seedrandom@^2.4.2:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.4.tgz#b25ea98632c73e45f58b77cfaa931678df01f9ba"
-
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
@@ -10660,12 +10666,6 @@ shebang-regex@^1.0.0:
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
-
-shuffle-seed@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/shuffle-seed/-/shuffle-seed-1.1.6.tgz#533c12683bab3b4fa3e8751fc4e562146744260b"
-  dependencies:
-    seedrandom "^2.4.2"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -10794,14 +10794,6 @@ socks@^1.1.10:
     ip "^1.1.4"
     smart-buffer "^1.0.13"
 
-sort-asc@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/sort-asc/-/sort-asc-0.1.0.tgz#ab799df61fc73ea0956c79c4b531ed1e9e7727e9"
-
-sort-desc@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/sort-desc/-/sort-desc-0.1.1.tgz#198b8c0cdeb095c463341861e3925d4ee359a9ee"
-
 sort-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
@@ -10811,13 +10803,6 @@ sort-keys@^2.0.0:
 sort-object-keys@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.2.tgz#d3a6c48dc2ac97e6bc94367696e03f6d09d37952"
-
-sort-object@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/sort-object/-/sort-object-0.3.2.tgz#98e0d199ede40e07c61a84403c61d6c3b290f9e2"
-  dependencies:
-    sort-asc "^0.1.0"
-    sort-desc "^0.1.1"
 
 sort-package-json@^1.15.0:
   version "1.16.0"
@@ -10941,6 +10926,10 @@ spdx-expression-parse@^3.0.0:
 spdx-license-ids@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz#e2a303236cac54b04031fa7a5a79c7e701df852f"
+
+splaytree@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-0.1.4.tgz#fc35475248edcc29d4938c9b67e43c6b7e55a659"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -11136,10 +11125,6 @@ strip-ansi@~0.1.0:
   version "0.1.1"
   resolved "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
 
-strip-bom-string@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom-string/-/strip-bom-string-1.0.0.tgz#e5211e9224369fbb81d633a2f00044dc8cedad92"
-
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -11174,7 +11159,7 @@ sum-up@^1.0.1:
   dependencies:
     chalk "^1.0.0"
 
-supercluster@^4.0.1, supercluster@^4.1.1:
+supercluster@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-4.1.1.tgz#cf13c3b28a3fb3db5290bfad7f524e244bd4ce78"
   dependencies:
@@ -11354,7 +11339,7 @@ three-way-merger@^0.5.0:
   dependencies:
     semver "^5.4.1"
 
-through2@^2.0.0, through2@^2.0.3, through2@~2.0.3:
+through2@^2.0.0, through2@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
   dependencies:
@@ -11390,7 +11375,7 @@ tiny-lr@^1.1.1:
     object-assign "^4.1.0"
     qs "^6.4.0"
 
-tinyqueue@^1.1.0:
+tinyqueue@^1.1.0, tinyqueue@^1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-1.2.3.tgz#b6a61de23060584da29f82362e45df1ec7353f3d"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4889,9 +4889,9 @@ ember-local-storage@^1.4.0:
     ember-cli-version-checker "^2.1.0"
     ember-copy "^1.0.0"
 
-ember-mapbox-composer@NYCPlanning/ember-mapbox-composer#refactor-highlighted-source:
-  version "0.0.19"
-  resolved "https://codeload.github.com/NYCPlanning/ember-mapbox-composer/tar.gz/72a7d2cef521c673dec7ecdc5182f22d00be1895"
+ember-mapbox-composer@0.0.22:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.0.21.tgz#11aa43fdf1b43aed64118c4c63ae60d2ec3e0bb3"
   dependencies:
     "@ember-decorators/babel-transforms" "^2.0.0"
     "@turf/union" "^6.0.0"
@@ -4905,6 +4905,7 @@ ember-mapbox-composer@NYCPlanning/ember-mapbox-composer#refactor-highlighted-sou
     ember-fetch "5.1.3"
     ember-font-awesome "^4.0.0-rc.2"
     ember-truth-helpers "2.0.0"
+    mapbox-gl ">=0.47.0"
     pretender "2.0.0"
 
 ember-mapbox-gl-draw@2.0.0:
@@ -5474,6 +5475,10 @@ eslint@^4.0.0, eslint@^4.19.1:
     strip-json-comments "~2.0.1"
     table "4.0.2"
     text-table "~0.2.0"
+
+esm@^3.0.84:
+  version "3.0.84"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.84.tgz#bb108989f4673b32d4f62406869c28eed3815a63"
 
 espree@^3.5.4:
   version "3.5.4"
@@ -6302,7 +6307,7 @@ geojson-rewind@^0.3.0:
     minimist "1.2.0"
     sharkdown "^0.1.0"
 
-geojson-vt@^3.2.0:
+geojson-vt@^3.2.0, geojson-vt@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"
 
@@ -8177,6 +8182,35 @@ mapbox-gl@0.50.0:
     earcut "^2.1.3"
     geojson-rewind "^0.3.0"
     geojson-vt "^3.2.0"
+    gl-matrix "^2.6.1"
+    grid-index "^1.0.0"
+    minimist "0.0.8"
+    murmurhash-js "^1.0.0"
+    pbf "^3.0.5"
+    potpack "^1.0.1"
+    quickselect "^1.0.0"
+    rw "^1.3.3"
+    supercluster "^4.1.1"
+    tinyqueue "^1.1.0"
+    vt-pbf "^3.0.1"
+
+mapbox-gl@>=0.47.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.51.0.tgz#2d521574408951ac848a436ceabca69a795a4897"
+  dependencies:
+    "@mapbox/geojson-types" "^1.0.2"
+    "@mapbox/jsonlint-lines-primitives" "^2.0.2"
+    "@mapbox/mapbox-gl-supported" "^1.4.0"
+    "@mapbox/point-geometry" "^0.1.0"
+    "@mapbox/tiny-sdf" "^1.1.0"
+    "@mapbox/unitbezier" "^0.0.0"
+    "@mapbox/vector-tile" "^1.3.1"
+    "@mapbox/whoots-js" "^3.1.0"
+    csscolorparser "~1.0.2"
+    earcut "^2.1.3"
+    esm "^3.0.84"
+    geojson-rewind "^0.3.0"
+    geojson-vt "^3.2.1"
     gl-matrix "^2.6.1"
     grid-index "^1.0.0"
     minimist "0.0.8"


### PR DESCRIPTION
This PR updates to latest version of mapbox-composer, which includes a number of fixes:
 - tile stitching for highlights
 - aggregate layer group state service
 - some bug fixes

@hannahkates there are still some bugs mainly with *inbound query params setting up map toggles correctly*, specifically with layer group "substate" (commercial overlays, for example, have several nested filters for types). Everything else seems fairly normal. 

The aerials also doesn't quite work with QPs just yet.

I am not fully comfortable promoting this to master. There needs to be a rewrite of:

1. Grouped controls for layer-group substate
2. layer-group substate should support other properties (filter, for example)

Let me know your thoughts. 
