### PR TITLE
convert zonemap to lowercase

### DIFF
--- a/app/models/lot.js
+++ b/app/models/lot.js
@@ -49,7 +49,7 @@ const LotColumnsSQL = [
   'zonedist2',
   'zonedist3',
   'zonedist4',
-  'zonemap',
+  'LOWER(zonemap) AS zonemap',
 ];
 
 const bldgclassLookup = {


### PR DESCRIPTION
MapPLUTO v18.1.1 contains different capitalization in the `zonemap` field, so we need to convert to lowercase in order to generate valid links to the zoning map PDFs.