### PR TITLE
fix typo in zoning_districts table name

### DIFF
--- a/app/adapters/zoning-district.js
+++ b/app/adapters/zoning-district.js
@@ -3,7 +3,7 @@ import { buildSqlUrl } from '../utils/carto';
 
 const SQL = function(id) {
   return `SELECT * FROM (
-  SELECT ST_CollectionExtract(ST_Collect(the_geom),3) as the_geom, zonedist as id FROM zoning_subdistricts_v20181206 GROUP BY zonedist
+  SELECT ST_CollectionExtract(ST_Collect(the_geom),3) as the_geom, zonedist as id FROM zoning_districts_v20181206 GROUP BY zonedist
 ) a WHERE id = '${id}'`;
 };
 

--- a/app/sources/zoning-districts.js
+++ b/app/sources/zoning-districts.js
@@ -10,7 +10,7 @@ export default {
                 WHEN SUBSTRING(zonedist, 3, 1) ~ E'[A-Z]' THEN LEFT(zonedist, 2)
                 WHEN SUBSTRING(zonedist, 3, 1) ~ E'[0-9]' THEN LEFT(zonedist, 3)
                 ELSE zonedist
-              END as primaryzone FROM zoning_subdistricts_v20181206
+              END as primaryzone FROM zoning_districts_v20181206
             ) a`,
     },
   ],

--- a/tests/integration/helpers/extract-layer-stops-for-test.js
+++ b/tests/integration/helpers/extract-layer-stops-for-test.js
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 const inputValue = {
   id: 'zoning',
   title: 'Zoning Districts',
-  sql: 'SELECT * FROM (SELECT *, LEFT(zonedist, 2) as primaryzone FROM zoning_subdistricts_v20181206) a',
+  sql: 'SELECT * FROM (SELECT *, LEFT(zonedist, 2) as primaryzone FROM zoning_districts_v20181206) a',
   type: 'carto',
   layers: [
     {


### PR DESCRIPTION
When updating to use the latest datasets, the zoning_districts table name was accidentally entered as zoning_subdistricts. This caused the route transitions to break when clicking on a zoning district.