### PR TITLE
Update mappluto table name + add devlocal

### DIFF
--- a/app/adapters/lot.js
+++ b/app/adapters/lot.js
@@ -5,7 +5,7 @@ import { LotColumnsSQL } from '../models/lot';
 const SQL = function(id) {
   return `SELECT ${LotColumnsSQL.join(',')}, 
     st_x(st_centroid(the_geom)) as lon, st_y(st_centroid(the_geom)) as lat,
-    the_geom, bbl AS id FROM mappluto_18v_1_1 WHERE bbl=${id}`;
+    the_geom, bbl AS id FROM mappluto_18v2 WHERE bbl=${id}`;
 };
 
 export default DS.JSONAPIAdapter.extend({

--- a/app/components/bbl-lookup.js
+++ b/app/components/bbl-lookup.js
@@ -62,7 +62,7 @@ export default Component.extend({
 
     goToLot() {
       const { boro: { code }, block, lot } = this;
-      const SQL = `select bbl from mappluto_18v_1_1 where borocode = ${code} and block = ${block} and lot = ${lot}`;
+      const SQL = `select bbl from mappluto_18v2 where borocode = ${code} and block = ${block} and lot = ${lot}`;
 
       carto.SQL(SQL)
         .then(([response]) => {

--- a/app/components/intersecting-layers.js
+++ b/app/components/intersecting-layers.js
@@ -25,7 +25,7 @@ const generateSQL = function(table, bbl) {
   }
 
   return `
-    WITH lot AS (SELECT the_geom FROM mappluto_18v_1_1 WHERE bbl = '${bbl}')
+    WITH lot AS (SELECT the_geom FROM mappluto_18v2 WHERE bbl = '${bbl}')
 
     SELECT true as intersects FROM ${intersectionTable} a, lot b WHERE ST_Intersects(a.the_geom, b.the_geom) LIMIT 1
   `;

--- a/app/sources/pluto.js
+++ b/app/sources/pluto.js
@@ -5,7 +5,7 @@ export default {
   'source-layers': [
     {
       id: 'pluto',
-      sql: 'SELECT the_geom_webmercator, bbl, lot, landuse, address FROM mappluto_18v_1_1',
+      sql: 'SELECT the_geom_webmercator, bbl, lot, landuse, address FROM mappluto_18v2',
     },
   ],
 };

--- a/app/templates/bookmarks.hbs
+++ b/app/templates/bookmarks.hbs
@@ -14,8 +14,8 @@
         <p class="text-small dark-gray" style="padding-left:1.5rem;">
           <span class="float-left" style="line-height:2;">Download saved Tax Lots (PLUTO) as:&nbsp;</span>
           <span class="nowrap">
-            <a class="button gray tiny" href={{carto-download-link 'mappluto_18v_1_1' 'bbl' (map-by 'bookmark.id' values) 'csv'}}>CSV</a>
-            <a class="button gray tiny" href={{carto-download-link 'mappluto_18v_1_1' 'bbl'
+            <a class="button gray tiny" href={{carto-download-link 'mappluto_18v2' 'bbl' (map-by 'bookmark.id' values) 'csv'}}>CSV</a>
+            <a class="button gray tiny" href={{carto-download-link 'mappluto_18v2' 'bbl'
             (map-by 'bookmark.id' values) 'shp'}}>Shapefile</a>
           </span>
         </p>

--- a/config/environment.js
+++ b/config/environment.js
@@ -107,7 +107,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'devlocal') {
-    // here you can enable a staging-specific feature
+    // here you can enable a devlocal-specific feature
     ENV.host = 'http://localhost:3000';
   }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -106,6 +106,11 @@ module.exports = function(environment) {
     ENV.APP.autoboot = false;
   }
 
+  if (environment === 'devlocal') {
+    // here you can enable a staging-specific feature
+    ENV.host = 'http://localhost:3000';
+  }
+
   if (environment === 'staging') {
     // here you can enable a staging-specific feature
     ENV.host = 'https://layers-api-staging.planninglabs.nyc';

--- a/scripts/sitemap.js
+++ b/scripts/sitemap.js
@@ -26,7 +26,7 @@ function createSitemap(rows) {
 
 function getData() {
   const offset = 50000 * count;
-  const sql = `SELECT bbl FROM mappluto_18v_1_1 LIMIT 50000 OFFSET ${offset}`;
+  const sql = `SELECT bbl FROM mappluto_18v2 LIMIT 50000 OFFSET ${offset}`;
 
   const apiCall = `https://planninglabs.carto.com/api/v2/sql?q=${sql}&format=json`;
 

--- a/tests/integration/helpers/carto-download-link-test.js
+++ b/tests/integration/helpers/carto-download-link-test.js
@@ -10,7 +10,7 @@ module('helper:carto-download-link', function(hooks) {
   // Replace this with your real tests.
   test('it renders', async function(assert) {
     this.setProperties({
-      table: 'mappluto_18v_1_1',
+      table: 'mappluto_18v2',
       identifier: 'bbl',
       ids: [1014970028, 1015280036, 1015280038],
       format: 'csv',
@@ -18,7 +18,7 @@ module('helper:carto-download-link', function(hooks) {
 
     await render(hbs`{{carto-download-link table identifier ids format}}`);
 
-    assert.equal(find('*').textContent.trim(), 'https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mappluto_18v_1_1 WHERE bbl IN (1014970028,1015280036,1015280038)&format=csv&filename=mappluto_18v_1_1');
+    assert.equal(find('*').textContent.trim(), 'https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mappluto_18v2 WHERE bbl IN (1014970028,1015280036,1015280038)&format=csv&filename=mappluto_18v2');
   });
 });
 


### PR DESCRIPTION
This PR:
- Updates MaPLUTO from v18.1.1 to v18.2
- Adds a devlocal environment to test the layers API while running it locally