### PR TITLE
735: Move 'Limited Height Districts' lg to supporting zoning layers

### DIFF
--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -192,13 +192,6 @@
         icon=layerGroups.special-purpose-subdistricts.legend.icon
         active=layerGroups.special-purpose-subdistricts.visible}}
     {{/labs-ui/layer-group-toggle}}
-
-    {{#labs-ui/layer-group-toggle
-        label=layerGroups.limited-height-districts.legend.label
-        tooltip=layerGroups.limited-height-districts.legend.tooltip
-        icon=layerGroups.limited-height-districts.legend.icon
-        active=layerGroups.limited-height-districts.visible}}
-    {{/labs-ui/layer-group-toggle}}
   {{/labs-ui/layer-groups-container}}
 
   {{#labs-ui/layer-groups-container
@@ -237,6 +230,13 @@
         tooltip=layerGroups.sidewalk-cafes.legend.tooltip
         active=layerGroups.sidewalk-cafes.visible}}
       {{labs-ui/legend-items items=layerGroups.sidewalk-cafes.legend.items}}
+    {{/labs-ui/layer-group-toggle}}
+
+    {{#labs-ui/layer-group-toggle
+        label=layerGroups.limited-height-districts.legend.label
+        tooltip=layerGroups.limited-height-districts.legend.tooltip
+        icon=layerGroups.limited-height-districts.legend.icon
+        active=layerGroups.limited-height-districts.visible}}
     {{/labs-ui/layer-group-toggle}}
 
     {{#labs-ui/layer-group-toggle


### PR DESCRIPTION
This PR moves the Limited Height Districts layer group to the supporting zoning layers section from zoning and land use section in the layer-palette component template

Closes #735 