### PR TITLE
697: Add housenum and street to lot model, expose HPD resource in lot profile template

### DIFF
--- a/app/models/lot.js
+++ b/app/models/lot.js
@@ -29,8 +29,7 @@ const LotColumnsSQL = [
   'numfloors',
   'ownername',
   'ownertype',
-  'overlay1',
-  'overlay2',
+  'overlay1', 'overlay2',
   'policeprct',
   'sanitboro',
   'sanitdistr',
@@ -483,6 +482,18 @@ export default class LotModel extends Bookmarkable {
   @computed('ownertype')
   get ownertypename() {
     return ownertypeLookup[this.ownertype];
+  }
+
+  @computed('address')
+  get housenum() {
+    const match = this.address.match(/([0-9-]*)\s[0-9A-Za-z\s]*/);
+    return match ? match[1] : '';
+  }
+
+  @computed('address')
+  get street() {
+    const match = this.address.match(/[0-9-]*\s([0-9A-Za-z\s]*)/);
+    return match ? match[1] : '';
   }
 }
 

--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -206,6 +206,16 @@
         </span>
       </div>
     {{/if}}
+    {{#if (and model.value.borocode model.value.address)}}
+      <div class="data-grid">
+        <label class="data-label">Housing Info</label>
+        <span class="datum">
+          <a href="https://hpdonline.hpdnyc.org/Hpdonline/Provide_address.aspx?p1={{model.value.boro}}&p2={{model.value.housenum}}&p3={{model.value.street}}&SearchButton=Search" target="_blank">
+            {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} View HPD's Building, Registration & Violation Records
+          </a>
+        </span>
+      </div>
+    {{/if}}
 
     <h3 class="header-small lot-section-header">Neighborhood Information</h3>
 


### PR DESCRIPTION
This PR adds housenum and street computed properties (from address -- parsed with regex) to lot model, and exposes HPD resource link in lot profile template. HPD resource link is compose from borocode, housenum, and street values. 

Screen shot shows how the link looks, inserted below ACRIS link

Closes #697

<img width="483" alt="screen shot 2019-01-31 at 1 36 25 pm" src="https://user-images.githubusercontent.com/6502129/52076832-88463700-255d-11e9-9bdc-6393a46871b0.png">