### PR TITLE
hide default street names, add dcp street labels

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -222,8 +222,14 @@ class MainMap extends Component {
     map.addControl(geoLocateControl, 'top-left');
     map.addControl(new MeasurementText(), 'top-left');
 
-    // get rid of default building layer
-    map.removeLayer('building');
+    // hide default base style layers
+    const basemapLayersToHide = [
+      'building',
+      'highway_name_other',
+      'highway_name_motorway',
+    ];
+
+    basemapLayersToHide.forEach(layer => map.removeLayer(layer));
 
     map.addSource('ee', {
       type: 'image',

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -20,6 +20,7 @@ export default Route.extend({
     const layerGroups = await this.store.query('layer-group', {
       'layer-groups': [
         { id: 'zoning-districts', visible: true },
+        { id: 'street-centerlines', visible: true },
         { id: 'tax-lots', visible: true, layers: [{ tooltipable: true }] },
         { id: 'commercial-overlays', visible: true },
         { id: 'zoning-map-amendments', visible: false },

--- a/tests/acceptance/visit-lot-test.js
+++ b/tests/acceptance/visit-lot-test.js
@@ -14,7 +14,7 @@ module('Acceptance | visit lot', function(hooks) {
   test('visiting a bbl', async function(assert) {
     await visit('/bbl/1001870021');
 
-    assert.equal(currentURL(), '/lot/1/187/21?layer-groups=%5B%22building-footprints%22%2C%22commercial-overlays%22%2C%22subway%22%2C%22tax-lots%22%2C%22zoning-districts%22%5D');
+    assert.equal(currentURL(), '/lot/1/187/21?layer-groups=%5B%22building-footprints%22%2C%22commercial-overlays%22%2C%22street-centerlines%22%2C%22subway%22%2C%22tax-lots%22%2C%22zoning-districts%22%5D');
     assert.notEqual(find('.content-area').textContent.length, 0);
   });
 });


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR replaces the default OSM street labels the official street name labels (including street width).  This is the same street label data used in [streets.planning.nyc.gov](https://streets.planning.nyc.gov)

Changes Proposed:
- manually remove `highway_name_other` and `highway_name_motorway`
- add `street-centerlines` layergroup with `visible:true`
Closes #699
