### PR TITLE
749 extract test helper; calibrate

### DIFF
--- a/app/services/main-map.js
+++ b/app/services/main-map.js
@@ -74,7 +74,7 @@ export default class MainMapService extends Service {
     // width of content area on large screens is 5/12 of full
     const contentWidth = (fullWidth / 12) * 5;
     // on small screens, no offset
-    const offset = fullWidth < 1024 ? 0 : -((width - contentWidth) / 2);
+    const offset = fullWidth < 1024 ? 0 : -((width - contentWidth) / 2) / 2;
     const padding = Math.min(height, (width - contentWidth)) / 2.5;
 
     // get type of selected feature so we can do dynamic padding

--- a/tests/helpers/setup-map-mocks.js
+++ b/tests/helpers/setup-map-mocks.js
@@ -1,8 +1,8 @@
 import { registerWaiter, unregisterWaiter } from '@ember/test';
 import LabsMap from 'ember-mapbox-composer/components/labs-map';
 import MapboxGL from 'ember-mapbox-gl/components/mapbox-gl';
+import TesterMap from './tester-map';
 import Service, { inject as service } from '@ember/service';
-import { inject as serviceDec } from '@ember-decorators/service';
 
 export default function(hooks) {
   hooks.beforeEach(async function() {
@@ -26,67 +26,6 @@ export default function(hooks) {
         this._super(...params);
       },
     }));
-
-    class TesterMap extends LabsMap {
-      didIdle = false;
-
-      @serviceDec
-      mockMapService;
-
-      init(...args) {
-        super.init(...args);
-
-        // register map reference
-        this.get('mockMapService.maps').set(this.elementId, this);
-
-        // test waiter
-        registerWaiter(this.testWaiter.bind(this));
-      }
-
-      willDestroyElement(...params) {
-        unregisterWaiter(this.testWaiter.bind(this));
-
-        this.map.off('idle', this.callbacks.willIdle);
-        this.map.off('render', this.callbacks.willRender);
-
-        this._super(...params);
-      }
-
-      testWaiter() {
-        if (this.map) {
-          return this.didIdle;
-        }
-
-        return false;
-      }
-
-      swapInImage(map) {
-        const target = this.element.querySelector('canvas') || this.element.querySelector('img');
-        target.outerHTML = `
-          <img src="${map.getCanvas().toDataURL()}"/>
-        `;
-      }
-
-      _onLoad(map) {
-        // callbacks
-        this.callbacks = {
-          willIdle: () => {
-            this.swapInImage(map);
-            this.didIdle = true;
-          },
-          willRender: () => {
-            this.swapInImage(map);
-          },
-        };
-
-        // override maploaded with an event listener that replaces
-        // the canvas with an image for testing purposes
-        map.on('idle', this.callbacks.willIdle);
-        map.on('render', this.callbacks.willRender);
-
-        super._onLoad(map);
-      }
-    }
 
     this.owner.register('component:labs-map', TesterMap);
   });

--- a/tests/helpers/tester-map.js
+++ b/tests/helpers/tester-map.js
@@ -1,0 +1,64 @@
+import LabsMap from 'ember-mapbox-composer/components/labs-map';
+import { registerWaiter, unregisterWaiter } from '@ember/test';
+import { inject as service } from '@ember-decorators/service';
+
+export default class TesterMap extends LabsMap {
+  didIdle = false;
+
+  @service
+  mockMapService;
+
+  init(...args) {
+    super.init(...args);
+
+    // register map reference
+    this.get('mockMapService.maps').set(this.elementId, this);
+
+    // test waiter
+    registerWaiter(this.testWaiter.bind(this));
+  }
+
+  willDestroyElement(...params) {
+    unregisterWaiter(this.testWaiter.bind(this));
+
+    this.map.off('idle', this.callbacks.willIdle);
+    this.map.off('render', this.callbacks.willRender);
+
+    this._super(...params);
+  }
+
+  testWaiter() {
+    if (this.map) {
+      return this.didIdle;
+    }
+
+    return false;
+  }
+
+  swapInImage(map) {
+    const target = this.element.querySelector('canvas') || this.element.querySelector('img');
+    target.outerHTML = `
+      <img src="${map.getCanvas().toDataURL()}"/>
+    `;
+  }
+
+  _onLoad(map) {
+    // callbacks
+    this.callbacks = {
+      willIdle: () => {
+        this.swapInImage(map);
+        this.didIdle = true;
+      },
+      willRender: () => {
+        this.swapInImage(map);
+      },
+    };
+
+    // override maploaded with an event listener that replaces
+    // the canvas with an image for testing purposes
+    map.on('idle', this.callbacks.willIdle);
+    map.on('render', this.callbacks.willRender);
+
+    super._onLoad(map);
+  }
+}


### PR DESCRIPTION
This PR closes #749 but tweaking the way `main-map` calculates the offset.

This bit of functionality should probably be reworked for a much saner approach, preferably one in which div elements are not overlapping the viewable map area. This means we can use other approaches to help reset the map when sibling divs change.

