### PR TITLE
Add ACRIS tooltip/fix tooltip viewing issues in tax-lot tab

### DIFF
--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -195,10 +195,23 @@
     {{#if model.value.unitstotal}}<div class="data-grid"><label class="data-label">Total # of Units</label><span class="datum">{{model.value.unitstotal}}</span></div>{{/if}}
     {{#if model.value.unitsres}}<div class="data-grid"><label class="data-label">Residential Units</label><span class="datum">{{model.value.unitsres}}</span></div>{{/if}}
     {{#if model.value.condono}}<div class="data-grid"><label class="data-label">Condominium Number</label><span class="datum">{{model.value.condono}}</span></div>{{/if}}
-    <div class="data-grid"><label class="data-label">Building Info {{labs-ui/icon-tooltip tip="View this lot's building listing on the NYC Department of Buildings' Building Information System (BISWEB) Application"}}</label><span class="datum"><a href="http://a810-bisweb.nyc.gov/bisweb/PropertyBrowseByBBLServlet?allborough={{model.value.borocode}}&allblock={{model.value.block}}&alllot={{model.value.lot}}&go5=+GO+&requestid=0" target="_blank">{{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} BISWEB </a></span></div>
+    <div class="data-grid"><label class="data-label">Building Info
+          <span>{{fa-icon "info-circle"}}
+          {{ember-tooltip
+            text="View this lot's building listing on the NYC Department of Buildings' Building Information System (BISWEB) Application"
+            side='right'
+          }}</span>
+        </label>
+        <span class="datum"><a href="http://a810-bisweb.nyc.gov/bisweb/PropertyBrowseByBBLServlet?allborough={{model.value.borocode}}&allblock={{model.value.block}}&alllot={{model.value.lot}}&go5=+GO+&requestid=0" target="_blank">{{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} BISWEB </a></span></div>
     {{#if model.value.borocode}}
       <div class="data-grid">
-        <label class="data-label">Property Records</label>
+        <label class="data-label">Property Records
+          <span>{{fa-icon "info-circle"}}
+          {{ember-tooltip
+          text="View this lot's property records from 1966 to the present on the NYC Department of Finance's Automated City Register Information System (ACRIS)."
+          side='right'
+        }}</span>
+      </label>
         <span class="datum">
           <a href="http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough={{model.value.borocode}}&block={{model.value.block}}&lot={{model.value.lot}}" target="_blank">
             {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} View ACRIS
@@ -229,7 +242,7 @@
     {{#if model.value.sanitsub}}<div class="data-grid"><label class="data-label">Sanitation Subsection</label><span class="datum">{{model.value.sanitsub}}</span></div>{{/if}}
 
     <hr>
-    {{road-view 
+    {{road-view
       lon=model.value.lon
       lat=model.value.lat
     }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4928,16 +4928,6 @@ ember-metrics@0.12.1:
     ember-getowner-polyfill "^2.0.0"
     ember-runtime-enumerable-includes-polyfill "^2.0.0"
 
-ember-native-class-polyfill@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ember-native-class-polyfill/-/ember-native-class-polyfill-1.0.6.tgz#cc7a3407d461acb797bd3253e433936a3261e8bc"
-  dependencies:
-    broccoli-debug "^0.6.5"
-    broccoli-funnel "^2.0.1"
-    ember-cli-babel "^7.1.3"
-    ember-cli-version-checker "^2.1.2"
-    semver "^5.6.0"
-
 ember-native-dom-helpers@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.2.tgz#ad1f82d64ac9abdd612022f4f390bdb6653b3d39"


### PR DESCRIPTION
This PR adds ACRIS tooltip to the tax-lot info tab and also replaces `labs-ui icon-tooltip` with `ember-tooltip` for these specific tooltips due to issues with viewing the message box. 
