### PR TITLE
764: use aliased views for new jan datasets

### DIFF
--- a/app/adapters/commercial-overlay.js
+++ b/app/adapters/commercial-overlay.js
@@ -2,12 +2,12 @@ import DS from 'ember-data';
 import { buildSqlUrl } from '../utils/carto';
 
 // const SQL = function(id) {
-//   return `SELECT *, overlay as id FROM commercial_overlays_v20181206 WHERE overlay='${id}'`;
+//   return `SELECT *, overlay as id FROM commercial_overlays WHERE overlay='${id}'`;
 // };
 
 const SQL = function(id) {
   return `SELECT * FROM (
-    SELECT ST_CollectionExtract(ST_Collect(the_geom),3) as the_geom, overlay as id, overlay FROM commercial_overlays_v20181206 GROUP BY overlay
+    SELECT ST_CollectionExtract(ST_Collect(the_geom),3) as the_geom, overlay as id, overlay FROM commercial_overlays GROUP BY overlay
   ) a WHERE id='${id}'`;
 };
 

--- a/app/adapters/special-purpose-district.js
+++ b/app/adapters/special-purpose-district.js
@@ -2,7 +2,7 @@ import DS from 'ember-data';
 import { buildSqlUrl } from '../utils/carto';
 
 const SQL = function(id) {
-  return `SELECT cartodb_id as id, the_geom, sdname, sdlbl FROM special_purpose_districts_v20181206 WHERE cartodb_id='${id}'`;
+  return `SELECT cartodb_id as id, the_geom, sdname, sdlbl FROM special_purpose_districts WHERE cartodb_id='${id}'`;
 };
 
 export default DS.JSONAPIAdapter.extend({

--- a/app/adapters/special-purpose-subdistrict.js
+++ b/app/adapters/special-purpose-subdistrict.js
@@ -2,7 +2,7 @@ import DS from 'ember-data';
 import { buildSqlUrl } from '../utils/carto';
 
 const SQL = function(id) {
-  return `SELECT cartodb_id as id, the_geom, spname, splbl, subdist, subsub FROM special_purpose_subdistricts_v20181206 WHERE cartodb_id='${id}'`;
+  return `SELECT cartodb_id as id, the_geom, spname, splbl, subdist, subsub FROM special_purpose_subdistricts WHERE cartodb_id='${id}'`;
 };
 
 export default DS.JSONAPIAdapter.extend({

--- a/app/adapters/zma.js
+++ b/app/adapters/zma.js
@@ -2,7 +2,7 @@ import DS from 'ember-data';
 import { buildSqlUrl } from '../utils/carto';
 
 const SQL = function(ulurpno) {
-  return `SELECT the_geom, ulurpno as id, project_na, effective, status, lucats FROM zoning_map_amendments_v20181206 WHERE ulurpno='${ulurpno}'`;
+  return `SELECT the_geom, ulurpno as id, project_na, effective, status, lucats FROM zoning_map_amendments WHERE ulurpno='${ulurpno}'`;
 };
 
 export default DS.JSONAPIAdapter.extend({

--- a/app/adapters/zoning-district.js
+++ b/app/adapters/zoning-district.js
@@ -3,7 +3,7 @@ import { buildSqlUrl } from '../utils/carto';
 
 const SQL = function(id) {
   return `SELECT * FROM (
-  SELECT ST_CollectionExtract(ST_Collect(the_geom),3) as the_geom, zonedist as id FROM zoning_districts_v20181206 GROUP BY zonedist
+  SELECT ST_CollectionExtract(ST_Collect(the_geom),3) as the_geom, zonedist as id FROM zoning_districts GROUP BY zonedist
 ) a WHERE id = '${id}'`;
 };
 

--- a/app/controllers/lot.js
+++ b/app/controllers/lot.js
@@ -50,7 +50,7 @@ export default Controller.extend(Bookmarkable, {
   parentSpecialPurposeDistricts: computedProp('model.value.geometry', function() {
     const geometry = this.get('model.value.geometry');
 
-    return carto.SQL(SQL('special_purpose_districts_v20181206', geometry))
+    return carto.SQL(SQL('special_purpose_districts', geometry))
       .then(response => response.map(
         (item) => {
           const [, [anchorName, boroName]] = specialPurposeCrosswalk

--- a/app/sources/commercial-overlays.js
+++ b/app/sources/commercial-overlays.js
@@ -4,7 +4,7 @@ export default {
   'source-layers': [
     {
       id: 'commercial-overlays',
-      sql: 'SELECT * FROM commercial_overlays_v20181206',
+      sql: 'SELECT * FROM commercial_overlays',
     },
   ],
 };

--- a/app/sources/supporting-zoning.js
+++ b/app/sources/supporting-zoning.js
@@ -4,15 +4,15 @@ export default {
   'source-layers': [
     {
       id: 'special-purpose-districts',
-      sql: 'SELECT the_geom_webmercator, cartodb_id, sdlbl, sdname FROM special_purpose_districts_v20181206',
+      sql: 'SELECT the_geom_webmercator, cartodb_id, sdlbl, sdname FROM special_purpose_districts',
     },
     {
       id: 'special-purpose-subdistricts',
-      sql: 'SELECT the_geom_webmercator, splbl, cartodb_id, spname, subdist FROM special_purpose_subdistricts_v20181206',
+      sql: 'SELECT the_geom_webmercator, splbl, cartodb_id, spname, subdist FROM special_purpose_subdistricts',
     },
     {
       id: 'mandatory-inclusionary-housing',
-      sql: 'SELECT the_geom_webmercator, projectnam, mih_option FROM mandatory_inclusionary_housing_v20181130',
+      sql: 'SELECT the_geom_webmercator, projectnam, mih_option FROM mandatory_inclusionary_housing',
     },
     {
       id: 'inclusionary-housing',
@@ -28,7 +28,7 @@ export default {
     },
     {
       id: 'sidewalk-cafes',
-      sql: 'SELECT the_geom_webmercator, cafetype FROM sidewalk_cafes_v20181206',
+      sql: 'SELECT the_geom_webmercator, cafetype FROM sidewalk_cafes',
     },
     {
       id: 'low-density-growth-mgmt-areas',
@@ -44,11 +44,11 @@ export default {
     },
     {
       id: 'zoning-map-amendments-pending',
-      sql: 'SELECT the_geom_webmercator, ulurpno, status, project_na FROM zoning_map_amendments_v20181206 WHERE status = \'Certified\'',
+      sql: 'SELECT the_geom_webmercator, ulurpno, status, project_na FROM zoning_map_amendments WHERE status = \'Certified\'',
     },
     {
       id: 'limited-height-districts',
-      sql: 'SELECT the_geom_webmercator, lhlbl FROM limited_height_districts_v20181206',
+      sql: 'SELECT the_geom_webmercator, lhlbl FROM limited_height_districts',
     },
     {
       id: 'business-improvement-districts',
@@ -56,7 +56,7 @@ export default {
     },
     {
       id: 'e-designations',
-      sql: 'SELECT the_geom_webmercator, bbl, ceqr_num, enumber, ulurp_num FROM e_designations_v20181130',
+      sql: 'SELECT the_geom_webmercator, bbl, ceqr_num, enumber, ulurp_num FROM e_designations',
     },
     {
       id: 'industrial-business-zones',

--- a/app/sources/zoning-districts.js
+++ b/app/sources/zoning-districts.js
@@ -10,7 +10,7 @@ export default {
                 WHEN SUBSTRING(zonedist, 3, 1) ~ E'[A-Z]' THEN LEFT(zonedist, 2)
                 WHEN SUBSTRING(zonedist, 3, 1) ~ E'[0-9]' THEN LEFT(zonedist, 3)
                 ELSE zonedist
-              END as primaryzone FROM zoning_districts_v20181206
+              END as primaryzone FROM zoning_districts
             ) a`,
     },
   ],

--- a/app/sources/zoning-map-amendments.js
+++ b/app/sources/zoning-map-amendments.js
@@ -4,7 +4,7 @@ export default {
   'source-layers': [
     {
       id: 'zoning-map-amendments',
-      sql: 'SELECT * FROM (SELECT the_geom_webmercator, to_char(effective, \'MM/DD/YYYY\') as effectiveformatted, effective, ulurpno, status, project_na FROM zoning_map_amendments_v20181206 WHERE status = \'Adopted\') a',
+      sql: 'SELECT * FROM (SELECT the_geom_webmercator, to_char(effective, \'MM/DD/YYYY\') as effectiveformatted, effective, ulurpno, status, project_na FROM zoning_map_amendments WHERE status = \'Adopted\') a',
     },
   ],
 };

--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -67,8 +67,8 @@
                 'lower_density_growth_management_areas_v201709'
                 'floodplain_firm2007_v0'
                 'floodplain_pfirm2015_v0'
-                'mandatory_inclusionary_housing_v20181130'
-                'e_designations_v20181130'
+                'mandatory_inclusionary_housing'
+                'e_designations'
                 'appendixj_designated_mdistricts_v201712'
               )
               bbl=model.value.bbl as |layers numberIntersecting|}}
@@ -136,7 +136,7 @@
               </li>
             {{/if}}
 
-            {{#if layers.mandatory_inclusionary_housing_v20181130}}
+            {{#if layers.mandatory_inclusionary_housing}}
               <li>
                 <a target="_blank" href="https://www1.nyc.gov/site/planning/plans/mih/mandatory-inclusionary-housing.page">
                   {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Mandatory Inclusionary Housing Area
@@ -144,7 +144,7 @@
               </li>
             {{/if}}
 
-            {{#if layers.e_designations_v20181130}}
+            {{#if layers.e_designations}}
               <li>
                 <a target="_blank" href="http://www.nyc.gov/html/oer/html/e-designation/e-designation.shtml">
                   {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Environmental Designation

--- a/tests/integration/helpers/extract-layer-stops-for-test.js
+++ b/tests/integration/helpers/extract-layer-stops-for-test.js
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 const inputValue = {
   id: 'zoning',
   title: 'Zoning Districts',
-  sql: 'SELECT * FROM (SELECT *, LEFT(zonedist, 2) as primaryzone FROM zoning_districts_v20181206) a',
+  sql: 'SELECT * FROM (SELECT *, LEFT(zonedist, 2) as primaryzone FROM zoning_districts) a',
   type: 'carto',
   layers: [
     {

--- a/tests/integration/helpers/get-unique-options-for-test.js
+++ b/tests/integration/helpers/get-unique-options-for-test.js
@@ -9,7 +9,7 @@ module('helper:get-unique-options-for', function(hooks) {
 
   // Replace this with your real tests.
   test('it renders', async function(assert) {
-    this.set('sql', 'SELECT * FROM commercial_overlays_v20181206');
+    this.set('sql', 'SELECT * FROM commercial_overlays');
 
     await render(hbs`{{get-unique-options-for 'overlay' sql}}`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4928,16 +4928,6 @@ ember-metrics@0.12.1:
     ember-getowner-polyfill "^2.0.0"
     ember-runtime-enumerable-includes-polyfill "^2.0.0"
 
-ember-native-class-polyfill@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ember-native-class-polyfill/-/ember-native-class-polyfill-1.0.6.tgz#cc7a3407d461acb797bd3253e433936a3261e8bc"
-  dependencies:
-    broccoli-debug "^0.6.5"
-    broccoli-funnel "^2.0.1"
-    ember-cli-babel "^7.1.3"
-    ember-cli-version-checker "^2.1.2"
-    semver "^5.6.0"
-
 ember-native-dom-helpers@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.6.2.tgz#ad1f82d64ac9abdd612022f4f390bdb6653b3d39"


### PR DESCRIPTION
Closes #764 by updating some Carto queries to use new aliased views that have been created on Carto for datasets that have new Jan versions.

More info about the views is available in the layers-api PR description: https://github.com/NYCPlanning/labs-layers-api/pull/106