### PR TITLE
Update use of labs-layers component

### DIFF
--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -11,7 +11,7 @@
   <div class="labs-map-loaded" style="display:none"></div>
   {{#map.labs-layers
     interactivity=interactivity
-    highlightedFeatureLayer=highlightedLotLayer
+    highlightedLineFeatureLayer=highlightedLotLayer
     onLayerClick=(action 'handleLayerClick')
     onLayerHighlight=(action 'handleLayerHighlight')
      as |layers|}}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ember-in-viewport": "^3.1.3",
     "ember-load-initializers": "^1.1.0",
     "ember-local-storage": "^1.4.0",
-    "ember-mapbox-composer": "0.1.2",
+    "ember-mapbox-composer": "0.2.0",
     "ember-mapbox-gl": "0.12.0",
     "ember-mapbox-gl-draw": "2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4867,9 +4867,10 @@ ember-local-storage@^1.4.0:
     ember-cli-version-checker "^2.1.0"
     ember-copy "^1.0.0"
 
-ember-mapbox-composer@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.1.2.tgz#88d647c969e7cb8c1dd090435cd5a79e83f63280"
+ember-mapbox-composer@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.2.0.tgz#97cf28edf7776f9e6cd01d0be32898d135ef3ddb"
+  integrity sha512-4mz6/aSDrxmcoOEiaxWpumG42A3+J6CZZoyn4KsWjd3NL0ZM/D1pq+2TnWpmktxS6BFcWPRE0BQqE6nXdnjbbA==
   dependencies:
     "@turf/union" "^6.0.0"
     cartobox-promises-utility "1.0.2"
@@ -4927,16 +4928,6 @@ ember-metrics@0.12.1:
     ember-cli-babel "^6.1.0"
     ember-getowner-polyfill "^2.0.0"
     ember-runtime-enumerable-includes-polyfill "^2.0.0"
-
-ember-native-class-polyfill@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ember-native-class-polyfill/-/ember-native-class-polyfill-1.0.6.tgz#cc7a3407d461acb797bd3253e433936a3261e8bc"
-  dependencies:
-    broccoli-debug "^0.6.5"
-    broccoli-funnel "^2.0.1"
-    ember-cli-babel "^7.1.3"
-    ember-cli-version-checker "^2.1.2"
-    semver "^5.6.0"
 
 ember-native-dom-helpers@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR updates the usage of the labs-layers component from ember-mapbox-composer addon version 0.2.0

Closes #736 
