### PR TITLE
684 block lot lookups

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -57,9 +57,9 @@ export default Controller.extend(mapQueryParams.Mixin, {
 
   mainMap: service(),
   metrics: service(),
-  boro: 0,
-  block: 0,
-  lot: 0,
+  boro: '',
+  block: '',
+  lot: '',
 
   isDefault: computedProp('queryParamsState', function() {
     const state = this.get('queryParamsState');
@@ -145,10 +145,15 @@ export default Controller.extend(mapQueryParams.Mixin, {
       this.resetQueryParams();
     },
 
-    flyTo() {
-      const { boro: { code: boro }, block, lot } = this;
-
-      this.transitionToRoute('lot', boro, block, lot);
+    handleLookupSuccess(center, zoom, bbl) {
+      // if onSuccess from labs-bbl-lookup includes bbl, transition to lot route for that bbl
+      // otherwise flyTo the block
+      if (bbl) {
+        const { boro, block, lot } = bblDemux(bbl);
+        this.transitionToRoute('lot', boro, block, lot);
+      } else {
+        this.get('mainMap.mapInstance').flyTo({ center, zoom });
+      }
     },
   },
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -35,11 +35,7 @@
           commercial-overlay='View Commerical Overlay'
           special-purpose-district='View Special Purpose District'
         )}}
-      {{labs-bbl-lookup
-        boro=boro
-        block=block
-        lot=lot
-        onSuccess=(action 'handleLookupSuccess')}}
+      {{labs-bbl-lookup onSuccess=(action 'handleLookupSuccess')}}
     </div>
 
     <div class="map-grid">

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -39,7 +39,7 @@
         boro=boro
         block=block
         lot=lot
-        flyTo=(action 'flyTo')}}
+        onSuccess=(action 'handleLookupSuccess')}}
     </div>
 
     <div class="map-grid">

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-import": "^2.12.0",
     "foundation-sites": "6.5.0-rc.4",
     "jquery": "3.3.1",
-    "labs-ember-search": "2.4.13",
+    "labs-ember-search": "^3.0.0",
     "labs-ui": "^0.0.18",
     "loader.js": "^4.7.0",
     "mapbox-gl": "0.52.0",

--- a/tests/acceptance/bbl-lookup-test.js
+++ b/tests/acceptance/bbl-lookup-test.js
@@ -1,4 +1,4 @@
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import {
   visit, click, fillIn, currentURL,
 } from '@ember/test-helpers';
@@ -10,7 +10,7 @@ module('Acceptance | bbl lookup', function(hooks) {
   setupApplicationTest(hooks);
   setupMapMocks(hooks);
 
-  skip('BBL lookup works', async function(assert) {
+  test('BBL lookup works', async function(assert) {
     await visit('/');
     await mapboxGlLoaded();
     await click('.bbl-lookup-toggle');
@@ -23,6 +23,6 @@ module('Acceptance | bbl lookup', function(hooks) {
 
     await click('.bbl-lookup-form .button');
 
-    assert.equal(currentURL(), '/lot/3/1/1');
+    assert.equal(currentURL().split('?')[0], '/lot/3/1/1');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7508,7 +7508,7 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-labs-ember-search@2.4.13:
+labs-ember-search@^2.4.13:
   version "2.4.13"
   resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-2.4.13.tgz#38649a3b0c087c4987a78bb6de43752b420c5283"
   dependencies:


### PR DESCRIPTION
*Depends on merge and publishing of API changes on `labs-ember-search` (https://github.com/NYCPlanning/labs-ember-search/pull/11)*

This PR adds handling for both block and lot lookups using `labs-bbl-lookup` component (part of `labs-ember-search` addon)

Changes Proposed:
- Uses new API in labs-ember-search 3.0.0
- Handles lot lookup by transitioning to `lot` route
- Handles block lookup by calling `flyTo` on the map

Closes #684
