### PR TITLE
Fix misleading mouse cursor issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ember-in-viewport": "^3.1.3",
     "ember-load-initializers": "^1.1.0",
     "ember-local-storage": "^1.4.0",
-    "ember-mapbox-composer": "0.1.2",
+    "ember-mapbox-composer": "0.2.1",
     "ember-mapbox-gl": "0.12.0",
     "ember-mapbox-gl-draw": "2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-import": "^2.12.0",
     "foundation-sites": "6.5.0-rc.4",
     "jquery": "3.3.1",
-    "labs-ember-search": "2.4.13",
+    "labs-ember-search": "3.0.0",
     "labs-ui": "^0.0.18",
     "loader.js": "^4.7.0",
     "mapbox-gl": "0.52.0",

--- a/tests/acceptance/bbl-lookup-test.js
+++ b/tests/acceptance/bbl-lookup-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import {
-  visit, click, fillIn, currentURL,
+  visit, click, typeIn, currentURL,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import mapboxGlLoaded from '../helpers/mapbox-gl-loaded';
@@ -18,8 +18,8 @@ module('Acceptance | bbl lookup', function(hooks) {
 
     await click('.ember-power-select-options li:nth-child(3)');
 
-    await fillIn('.bbl-lookup--block-input', 1);
-    await fillIn('.bbl-lookup--lot-input', 1);
+    await typeIn('.bbl-lookup--block-input', '1');
+    await typeIn('.bbl-lookup--lot-input', '1');
 
     await click('.bbl-lookup-form .button');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4873,9 +4873,9 @@ ember-local-storage@^1.4.0:
     ember-cli-version-checker "^2.1.0"
     ember-copy "^1.0.0"
 
-ember-mapbox-composer@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.1.2.tgz#88d647c969e7cb8c1dd090435cd5a79e83f63280"
+ember-mapbox-composer@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.2.1.tgz#f38dc4330225286cfee53794ae8f302e4c5c571d"
   dependencies:
     "@turf/union" "^6.0.0"
     cartobox-promises-utility "1.0.2"
@@ -4886,6 +4886,7 @@ ember-mapbox-composer@0.1.2:
     ember-copy "1.0.0"
     ember-fetch "5.1.3"
     ember-truth-helpers "^2.0.0"
+    lodash "^4.17.11"
     mapbox-gl ">=0.47.0"
     pretender "2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,6 +760,10 @@
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.13.tgz#17f3d30c53732f07a765199c3cf93b4834e8cfde"
 
+"@fortawesome/fontawesome-common-types@^0.2.14":
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.14.tgz#0eb86a77ac88e8c12c48591735283f0bf0ea5606"
+
 "@fortawesome/fontawesome-svg-core@^1.2.0":
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.13.tgz#1d0923b9692fc10b9a4fa047d504da5d9941639e"
@@ -777,6 +781,12 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.7.0.tgz#b0127111924a2506cb6313dfcb140f0cbc9e35b1"
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.13"
+
+"@fortawesome/free-regular-svg-icons@^5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.7.1.tgz#eab182769eef910f961ed4c3a581ebd9934b4b38"
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.14"
 
 "@fortawesome/free-solid-svg-icons@^5.1.0", "@fortawesome/free-solid-svg-icons@^5.7.0":
   version "5.7.0"
@@ -7509,11 +7519,12 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-labs-ember-search@2.4.13:
-  version "2.4.13"
-  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-2.4.13.tgz#38649a3b0c087c4987a78bb6de43752b420c5283"
+labs-ember-search@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-3.0.0.tgz#ec1c3f32bc59cd9b90a9c7844731cac97fb86d22"
   dependencies:
     "@fortawesome/ember-fontawesome" "^0.1.9"
+    "@fortawesome/free-regular-svg-icons" "^5.7.1"
     "@fortawesome/free-solid-svg-icons" "^5.7.0"
     babel-plugin-htmlbars-inline-precompile "1.0.0"
     cartobox-promises-utility "1.0.2"


### PR DESCRIPTION
Closes #658 (NYCPlanning/ember-mapbox-composer#31) by updating composer version which includes handling for “clickable” layer groups