### PR TITLE
prevent SVGs intercepting print controls click event

### DIFF
--- a/app/styles/layouts/_l-print.scss
+++ b/app/styles/layouts/_l-print.scss
@@ -37,6 +37,10 @@
     @media print {
       display: none;
     }
+
+    svg {
+      pointer-events: none;
+    }
   }
 
   .print-button {
@@ -56,6 +60,7 @@
     display: inline;
     color: $charcoal;
   }
+
 
   //
   // Paper


### PR DESCRIPTION
This PR prevents the SVGs in the print controls buttons from intercepting the component's click event. 

The bug was that… 

When you clicked on a print control button — e.g. the landscape button — a `mut` action on the button changed the attribute and a `click` event on the `print-view-controls` component triggered a window resize for the map. If that click was on the SVG within the button, the action would work fine but the SVG would intercept the click event. So the print layout would change but the map would not resize unless you clicked a part of the button other than the SVG. 