### PR TITLE
639: Fix duplicate display of first commercial overlay in zoning district list

### DIFF
--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -45,7 +45,7 @@
 
         {{#if model.value.overlay2}}
           <li>
-            <a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/c1-c2-overlays.page" target="_blank" class="button">{{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} {{model.value.overlay1}}</a>
+            <a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/c1-c2-overlays.page" target="_blank" class="button">{{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} {{model.value.overlay2}}</a>
           </li>
         {{/if}}
       </ul>


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR fixes a typo in the lot content component template that was displaying `lot.overlay1` twice, instead of `lot.overlay1` and `lot.overlay2` from the lot model

Closes #639 
