### PR TITLE
No-content Printing 

### DIFF
--- a/app/styles/layouts/_l-print.scss
+++ b/app/styles/layouts/_l-print.scss
@@ -61,6 +61,13 @@
     color: $charcoal;
   }
 
+  .index-active-detector.active ~ .print-view--controls .print-view-controls--item.show {
+    .map,
+    .content {
+      display: none;
+    }
+  }
+
 
   //
   // Paper
@@ -215,10 +222,14 @@
       right: 7mm;
     }
 
+    @mixin full-height-map {
+      height: calc(100% - 21mm);
+    }
+
     &.portrait {
       // Portrait + letter
       &.no-content .map-container {
-        height: calc(100% - 21mm);
+        @include full-height-map
       }
 
       &.no-legend .map-container {
@@ -232,6 +243,12 @@
       &.legal:not(.no-content) .map-container {
         height: calc(57% - 10.5mm);
       }
+      &.legal.no-map .content-area {
+        top: 7mm;
+      }
+      &.legal.no-legend .content-area {
+        right: 7mm;
+      }
 
       // Portrait + tabloid
       &.tabloid .content-area {
@@ -240,12 +257,26 @@
       &.tabloid:not(.no-content) .map-container {
         height: calc(64% - 10.5mm);
       }
+      &.tabloid.no-map .content-area {
+        top: 7mm;
+      }
+      &.tabloid.no-legend .content-area {
+        right: 7mm;
+      }
+
+      // There's no content when index is active
+      @at-root .index-active-detector.active ~ .paper.portrait .map-container { @include full-height-map }
+      @at-root .index-active-detector.active ~ .paper.portrait.legal .map-container { @include full-height-map }
+      @at-root .index-active-detector.active ~ .paper.portrait.tabloid .map-container { @include full-height-map }
     } // end .portrait
 
     &.landscape {
       // Landscape + letter
       &.no-content .map-container {
         height: calc(100% - 21mm);
+      }
+      @at-root .index-active-detector.active ~ .paper.landscape .map-container {
+        @include full-height-map
       }
 
       &.no-legend {
@@ -262,6 +293,9 @@
       }
 
       &.no-legend.no-content .map-container {
+        left: 7mm;
+      }
+      @at-root .index-active-detector.active ~ .paper.landscape.no-legend .map-container {
         left: 7mm;
       }
 
@@ -283,7 +317,10 @@
         right: 7mm;
       }
       &.legal.no-content .map-container {
-        left: 0;
+        left: 7mm;
+      }
+      @at-root .index-active-detector.active ~ .paper.landscape.legal .map-container {
+        left: 7mm;
       }
       &.legal.no-legend.no-content .map-container {
         left: 7mm;
@@ -307,7 +344,10 @@
         right: 7mm;
       }
       &.tabloid.no-content .map-container {
-        left: 0;
+        left: 7mm;
+      }
+      @at-root .index-active-detector.active ~ .paper.landscape.tabloid .map-container {
+        left: 7mm;
       }
       &.tabloid.no-legend.no-content .map-container {
         left: 7mm;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -24,6 +24,8 @@
 {{/labs-ui/site-header}}
 
 <div class="{{if print 'print-view'}}">
+  {{link-to '' 'index' class="index-active-detector"}}
+
   {{#if print}}
     {{print-view-controls
       print=print

--- a/app/templates/components/print-view-controls.hbs
+++ b/app/templates/components/print-view-controls.hbs
@@ -3,7 +3,7 @@
   Exit Print View
 </button>
 
-<div class="print-view-controls--item">
+<div class="print-view-controls--item orientation">
   <h6 class="print-view-controls--header">Orientation:</h6>
   <button
     onclick={{action (mut printViewOrientation) 'landscape'}}
@@ -37,7 +37,7 @@
   </button>
 </div>
 
-<div class="print-view-controls--item">
+<div class="print-view-controls--item size">
   <h6 class="print-view-controls--header">Size:</h6>
   <button
     onclick={{action (mut printViewPaperSize) 'letter'}}
@@ -86,9 +86,10 @@
   </button>
 </div>
 
-<div class="print-view-controls--item">
+<div class="print-view-controls--item show">
   <h6 class="print-view-controls--header">Show:</h6>
   <button
+    class="map"
     onclick={{action (mut printViewShowMap) (not printViewShowMap)}}
     data-test-print-control="map"
   >
@@ -104,6 +105,7 @@
   </button>
   {{#if (eq printViewShowMap true)}}
     <button
+      class="legend"
       onclick={{action (mut printViewShowLegend) (not printViewShowLegend)}}
       data-test-print-control="legend"
     >
@@ -125,6 +127,7 @@
     </button>
   {{/if}}
   <button
+    class="content"
     onclick={{action (mut printViewShowContent) (not printViewShowContent)}}
     data-test-print-control="content"
   >


### PR DESCRIPTION
This PR removes the "Content" checkbox in the print settings when there is no content to print (when you're on the index route). It use a "index-active-detector" — which is an invisible Ember `{{link-to}}` component that gets an active state when you're on the index page — and general sibling selectors to adjust styles when you're on the index route. 

Also fixes a couple print layout bugs where the map was aligned to the edge of the paper, without any margin. 

_* This index-active-detector method is used on other apps like Waterfront to determine how tall the map should be on mobile when the layer menu is open/closed._

Closes #789