### PR TITLE
use-aliased-data

### DIFF
--- a/app/adapters/lot.js
+++ b/app/adapters/lot.js
@@ -5,7 +5,7 @@ import { LotColumnsSQL } from '../models/lot';
 const SQL = function(id) {
   return `SELECT ${LotColumnsSQL.join(',')}, 
     st_x(st_centroid(the_geom)) as lon, st_y(st_centroid(the_geom)) as lat,
-    the_geom, bbl AS id FROM mappluto_18v2 WHERE bbl=${id}`;
+    the_geom, bbl AS id FROM mappluto WHERE bbl=${id}`;
 };
 
 export default DS.JSONAPIAdapter.extend({

--- a/app/components/intersecting-layers.js
+++ b/app/components/intersecting-layers.js
@@ -8,24 +8,24 @@ import carto from '../utils/carto';
 const generateSQL = function(table, bbl) {
   // special handling for tables where we don't want to SELECT *
   let intersectionTable = table;
-  if (table === 'floodplain_firm2007_v0') {
+  if (table === 'floodplain_firm2007') {
     intersectionTable = `(
       SELECT the_geom
-      FROM floodplain_firm2007_v0
+      FROM floodplain_firm2007
       WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'
     )`;
   }
 
-  if (table === 'floodplain_pfirm2015_v0') {
+  if (table === 'floodplain_pfirm2015') {
     intersectionTable = `(
       SELECT the_geom
-      FROM floodplain_pfirm2015_v0
+      FROM floodplain_pfirm2015
       WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'
     )`;
   }
 
   return `
-    WITH lot AS (SELECT the_geom FROM mappluto_18v2 WHERE bbl = '${bbl}')
+    WITH lot AS (SELECT the_geom FROM mappluto WHERE bbl = '${bbl}')
 
     SELECT true as intersects FROM ${intersectionTable} a, lot b WHERE ST_Intersects(a.the_geom, b.the_geom) LIMIT 1
   `;

--- a/app/sources/effective-flood-insurance-rate-2007.js
+++ b/app/sources/effective-flood-insurance-rate-2007.js
@@ -10,7 +10,7 @@ export default {
           WHEN fld_zone IN ('A', 'A0', 'AE') THEN 'A'
           WHEN fld_zone = 'VE' THEN 'V'
         END as fld_zone
-        FROM floodplain_firm2007_v0
+        FROM floodplain_firm2007
         WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'
       `,
     },

--- a/app/sources/pluto.js
+++ b/app/sources/pluto.js
@@ -5,7 +5,7 @@ export default {
   'source-layers': [
     {
       id: 'pluto',
-      sql: 'SELECT the_geom_webmercator, bbl, lot, landuse, address FROM mappluto_18v2',
+      sql: 'SELECT the_geom_webmercator, bbl, lot, landuse, address FROM mappluto',
     },
   ],
 };

--- a/app/sources/preliminary-flood-insurance-rate.js
+++ b/app/sources/preliminary-flood-insurance-rate.js
@@ -11,7 +11,7 @@ export default {
           WHEN fld_zone = 'VE' THEN 'V'
           WHEN fld_zone = '0.2 PCT ANNUAL CHANCE FLOOD HAZARD' THEN 'Shaded X'
         END as fld_zone
-        FROM floodplain_pfirm2015_v0
+        FROM floodplain_pfirm2015
         WHERE fld_zone IN ('A', 'A0', 'AE') OR fld_zone = 'VE'
       `,
     },

--- a/app/sources/supporting-zoning.js
+++ b/app/sources/supporting-zoning.js
@@ -16,15 +16,15 @@ export default {
     },
     {
       id: 'inclusionary-housing',
-      sql: 'SELECT the_geom_webmercator, projectnam FROM inclusionary_housing_v201804',
+      sql: 'SELECT the_geom_webmercator, projectnam FROM inclusionary_housing',
     },
     {
       id: 'transit-zones',
-      sql: 'SELECT the_geom_webmercator FROM transitzones_v201607',
+      sql: 'SELECT the_geom_webmercator FROM transitzones',
     },
     {
       id: 'fresh',
-      sql: 'SELECT the_geom_webmercator, name FROM fresh_zones_v201611',
+      sql: 'SELECT the_geom_webmercator, name FROM fresh_zones',
     },
     {
       id: 'sidewalk-cafes',
@@ -32,15 +32,15 @@ export default {
     },
     {
       id: 'low-density-growth-mgmt-areas',
-      sql: 'SELECT the_geom_webmercator FROM lower_density_growth_management_areas_v201709',
+      sql: 'SELECT the_geom_webmercator FROM lower_density_growth_management_areas',
     },
     {
       id: 'coastal-zone-boundary',
-      sql: 'SELECT the_geom_webmercator FROM coastal_zone_boundary_v201601',
+      sql: 'SELECT the_geom_webmercator FROM coastal_zone_boundary',
     },
     {
       id: 'waterfront-access-plan',
-      sql: 'SELECT the_geom_webmercator, name FROM waterfront_access_plan_v201109',
+      sql: 'SELECT the_geom_webmercator, name FROM waterfront_access_plan',
     },
     {
       id: 'zoning-map-amendments-pending',
@@ -64,7 +64,7 @@ export default {
     },
     {
       id: 'appendixj-designated-mdistricts',
-      sql: 'SELECT the_geom_webmercator, name, subarea FROM appendixj_designated_mdistricts_v201712',
+      sql: 'SELECT the_geom_webmercator, name, subarea FROM appendixj_designated_mdistricts',
     },
   ],
 };

--- a/app/templates/bookmarks.hbs
+++ b/app/templates/bookmarks.hbs
@@ -14,8 +14,8 @@
         <p class="text-small dark-gray" style="padding-left:1.5rem;">
           <span class="float-left" style="line-height:2;">Download saved Tax Lots (PLUTO) as:&nbsp;</span>
           <span class="nowrap">
-            <a class="button gray tiny" href={{carto-download-link 'mappluto_18v2' 'bbl' (map-by 'bookmark.id' values) 'csv'}}>CSV</a>
-            <a class="button gray tiny" href={{carto-download-link 'mappluto_18v2' 'bbl'
+            <a class="button gray tiny" href={{carto-download-link 'mappluto' 'bbl' (map-by 'bookmark.id' values) 'csv'}}>CSV</a>
+            <a class="button gray tiny" href={{carto-download-link 'mappluto' 'bbl'
             (map-by 'bookmark.id' values) 'shp'}}>Shapefile</a>
           </span>
         </p>

--- a/app/templates/lot.hbs
+++ b/app/templates/lot.hbs
@@ -60,21 +60,21 @@
 
             {{#intersecting-layers
                 tables=(array
-                  'inclusionary_housing_v201804'
-                  'transitzones_v201607'
-                  'fresh_zones_v201611'
-                  'waterfront_access_plan_v201109'
-                  'coastal_zone_boundary_v201601'
-                  'lower_density_growth_management_areas_v201709'
-                  'floodplain_firm2007_v0'
-                  'floodplain_pfirm2015_v0'
+                  'inclusionary_housing'
+                  'transitzones'
+                  'fresh_zones'
+                  'waterfront_access_plan'
+                  'coastal_zone_boundary'
+                  'lower_density_growth_management_areas'
+                  'floodplain_firm2007'
+                  'floodplain_pfirm2015'
                   'mandatory_inclusionary_housing'
                   'e_designations'
-                  'upland_waterfront_areas_v200912'
-                  'appendixj_designated_mdistricts_v201712'
+                  'upland_waterfront_areas'
+                  'appendixj_designated_mdistricts'
                 )
                 bbl=model.value.bbl as |layers numberIntersecting|}}
-              {{#if layers.inclusionary_housing_v201804}}
+              {{#if layers.inclusionary_housing}}
                 <li>
                   <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/districts-tools/inclusionary-housing.page">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Inclusionary Housing Zone
@@ -82,7 +82,7 @@
                 </li>
               {{/if}}
 
-              {{#if layers.transitzones_v201607}}
+              {{#if layers.transitzones}}
                 <li>
                   <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/glossary.page#transit_zone">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Transit Zone
@@ -90,7 +90,7 @@
                 </li>
               {{/if}}
 
-              {{#if layers.fresh_zones_v201611}}
+              {{#if layers.fresh_zones}}
                 <li>
                   <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/districts-tools/fresh-food-stores.page">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} FRESH Zone
@@ -98,7 +98,7 @@
                 </li>
               {{/if}}
 
-              {{#if layers.waterfront_access_plan_v201109}}
+              {{#if layers.waterfront_access_plan}}
                 <li>
                   <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/districts-tools/waterfront-zoning.page#waterfront_access_plan">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Waterfront Access Plan
@@ -106,7 +106,7 @@
                 </li>
               {{/if}}
 
-              {{#if layers.upland_waterfront_areas_v200912}}
+              {{#if layers.upland_waterfront_areas}}
                 <li>
                   <a target="_blank" href="https://www1.nyc.gov/site/planning/zoning/districts-tools/waterfront-zoning.page">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Waterfront Block
@@ -114,7 +114,7 @@
                 </li>
               {{/if}}
 
-              {{#if layers.coastal_zone_boundary_v201601}}
+              {{#if layers.coastal_zone_boundary}}
                 <li>
                   <a target="_blank" href="http://www1.nyc.gov/site/planning/applicants/wrp/wrp.page">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Coastal Zone
@@ -122,7 +122,7 @@
                 </li>
               {{/if}}
 
-              {{#if layers.lower_density_growth_management_areas_v201709}}
+              {{#if layers.lower_density_growth_management_areas}}
                 <li>
                   <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/districts-tools/lower-density-growth-mngmt.page">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Lower Density Growth Management Zone
@@ -130,7 +130,7 @@
                 </li>
               {{/if}}
 
-              {{#if layers.floodplain_firm2007_v0}}
+              {{#if layers.floodplain_firm2007}}
                 <li>
                   <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/districts-tools/flood-text.page">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Flood Zone
@@ -138,7 +138,7 @@
                 </li>
               {{/if}}
 
-              {{#if layers.floodplain_pfirm2015_v0}}
+              {{#if layers.floodplain_pfirm2015}}
                 <li>
                   <a target="_blank" href="http://www1.nyc.gov/site/planning/zoning/districts-tools/flood-text.page">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Flood Zone
@@ -162,7 +162,7 @@
                 </li>
               {{/if}}
 
-              {{#if layers.appendixj_designated_mdistricts_v201712}}
+              {{#if layers.appendixj_designated_mdistricts}}
                 <li>
                   <a target="_blank" href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-text/appendixj.pdf">
                     {{fa-icon 'external-link-alt' transform='shrink-3 up-1'}} Appendix J Designated M District

--- a/public/layer-groups.json
+++ b/public/layer-groups.json
@@ -154,7 +154,7 @@
         "meta": {
           "description": "Appendix J Designated M Districts Shapefile",
           "url": [
-            "https:\/\/planninglabs.carto.com\/api\/v2\/sql?q=SELECT * FROM appendixj_designated_mdistricts_v201712&format=SHP"
+            "https:\/\/planninglabs.carto.com\/api\/v2\/sql?q=SELECT * FROM appendixj_designated_mdistricts&format=SHP"
           ],
           "updated-at": "3 May 2018"
         },

--- a/scripts/sitemap.js
+++ b/scripts/sitemap.js
@@ -26,7 +26,7 @@ function createSitemap(rows) {
 
 function getData() {
   const offset = 50000 * count;
-  const sql = `SELECT bbl FROM mappluto_18v2 LIMIT 50000 OFFSET ${offset}`;
+  const sql = `SELECT bbl FROM mappluto LIMIT 50000 OFFSET ${offset}`;
 
   const apiCall = `https://planninglabs.carto.com/api/v2/sql?q=${sql}&format=json`;
 

--- a/tests/integration/helpers/carto-download-link-test.js
+++ b/tests/integration/helpers/carto-download-link-test.js
@@ -10,7 +10,7 @@ module('helper:carto-download-link', function(hooks) {
   // Replace this with your real tests.
   test('it renders', async function(assert) {
     this.setProperties({
-      table: 'mappluto_18v2',
+      table: 'mappluto',
       identifier: 'bbl',
       ids: [1014970028, 1015280036, 1015280038],
       format: 'csv',
@@ -18,6 +18,6 @@ module('helper:carto-download-link', function(hooks) {
 
     await render(hbs`{{carto-download-link table identifier ids format}}`);
 
-    assert.equal(find('*').textContent.trim(), 'https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mappluto_18v2 WHERE bbl IN (1014970028,1015280036,1015280038)&format=csv&filename=mappluto_18v2');
+    assert.equal(find('*').textContent.trim(), 'https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mappluto WHERE bbl IN (1014970028,1015280036,1015280038)&format=csv&filename=mappluto');
   });
 });


### PR DESCRIPTION
This PR updates Carto queries to query from aliased views of the latest dataset version. This reduces data maintenance overhead (now we only need to redefine the view when we get a new data version instead of find/replacing the table name throughout the code base) and makes this app match data view references used in all our other apps.

Related to https://github.com/NYCPlanning/labs-layers-api/pull/124