### PR TITLE
Change `/about` redirect; keep zoom hash through clicks

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,10 +1,23 @@
 import EmberRouter from '@ember/routing/router';
+import { inject as service } from '@ember/service';
 import config from './config/environment';
 import trackPage from './mixins/track-page';
 
+
 const Router = EmberRouter.extend(trackPage, {
+  mainMap: service(),
+
   location: config.locationType,
   rootURL: config.rootURL,
+
+  didTransition() {
+    // hack and a half: if the map exists, change it's zoom level by an unnoticable amount
+    // this will make mapboxgl put the viewport hash back in the current url
+    const map = this.get('mainMap.mapInstance');
+    if (map) map.flyTo({ zoom: map.getZoom() + 0.001 });
+
+    this._super();
+  },
 });
 
 Router.map(function () { // eslint-disable-line

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -43,9 +43,9 @@ export default Route.extend({
   mainMap: service(),
   layerGroupService: service('layerGroups'),
 
-  beforeModel({ targetName }) {
-    // only transition to about if index is loaded and there is no hash
-    if (targetName === 'index') {
+  beforeModel({ targetName, intent }) {
+    // only transition to about if the url is /
+    if (intent.url === '/') {
       this.transitionTo('about');
     }
 

--- a/tests/acceptance/bbox-test.js
+++ b/tests/acceptance/bbox-test.js
@@ -12,7 +12,7 @@ module('Acceptance | bbox', function(hooks) {
     assert.equal(currentURL(), `/bbox/${goodBboxUrl}`);
   });
 
-  test('visiting invalid bbox redirects to /about', async function(assert) {
+  test('visiting invalid bbox redirects to /', async function(assert) {
     const badBboxUrl = 'foo/40.5705/-73.9804/40.5785';
     await visit(`/bbox/${badBboxUrl}`);
 


### PR DESCRIPTION
This PR:

- Hotfix: Only redirect to `/About` if the original url requested was `/`.  

- Hotfix: Add hack to ensure mapboxGL viewport hash remains after internal route transitions. (ensures that no matter where the user is in the app, the URL can be shared and will present the same map view.
