### PR TITLE
849: add integration test for layer-palette

### DIFF
--- a/app/components/layer-palette.js
+++ b/app/components/layer-palette.js
@@ -83,16 +83,15 @@ export default class LayerPaletteComponent extends Component {
 
   plutoFill = false;
 
-  @observes('selectedZoning')
+  @observes('selectedZoning.@each')
   setFilterForZoning() {
     const expression = ['any', ...this.selectedZoning.map(value => ['==', 'primaryzone', value])];
-
     next(() => {
       this.layerGroups['zoning-districts'].setFilterForLayer('zd-fill', expression);
     });
   }
 
-  @observes('selectedOverlays')
+  @observes('selectedOverlays.@each')
   setFilterForOverlays() {
     const expression = ['any', ...this.selectedOverlays.map(value => ['==', 'overlay', value])];
 

--- a/app/components/map-measurement-tools.js
+++ b/app/components/map-measurement-tools.js
@@ -84,7 +84,7 @@ export default class MapMeasurementToolsComponent extends Component {
     if (features.length > 0) {
       const feature = features[0];
 
-      const drawnMeasurements = await metricCalculation(feature);
+      const drawnMeasurements = await metricCalculation(feature); // eslint-disable-line
 
       this.set('drawnMeasurements', drawnMeasurements);
     }

--- a/app/templates/components/grouped-checkboxes.hbs
+++ b/app/templates/components/grouped-checkboxes.hbs
@@ -20,7 +20,7 @@
   {{/if}}
 
   <ul class="nested columns-3 hidable-sibling" data-test-grouped={{group.name}}>
-    {{#each group.codes as |code|}} 
+    {{#each group.codes as |code|}}
       <li>
         <label>
           <input type='checkbox'

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -7,7 +7,6 @@
     title='Zoning and Land Use'
     as |container|
   }}
-
     {{#container.layer-group-toggle
       data-test-toggle-tax-lots
       label=layerGroups.tax-lots.legend.label
@@ -15,6 +14,7 @@
       active=layerGroups.tax-lots.visible
     }}
       <label class="checkbox-wrapper"
+        data-test-layer-option="land-use-checkbox"
         onclick={{action 'setPaintForLayerGroup'
           layerGroups.tax-lots
           'pluto-fill'
@@ -373,7 +373,7 @@
         {{#each layerGroups.aerials.layers as |layer|}}
           <li onclick={{action (mut layerGroups.aerials.selected) layer.id}} role='button'>
             <label {{!template-lint-disable "nested-interactive"}}>
-              <span class="layer-group-radio-{{layer.id}}">
+              <span class="layer-group-radio-{{layer.id}}" data-test-radio={{layer.id}}>
                 <span class="fa-layers">
                   {{#if layer.visibility}}
                     {{fa-icon 'dot-circle' prefix='far' class=(if layer.visibility '' 'silver')}}

--- a/tests/acceptance/navigating-to-qpd-url-breaks-test.js
+++ b/tests/acceptance/navigating-to-qpd-url-breaks-test.js
@@ -14,21 +14,21 @@ module('Acceptance | navigating to qpd url breaks', function(hooks) {
     this.server.post('layer-groups', () => layerGroupsFixtures);
   });
 
-  test('Visiting index with QPs directly doesnt break', async function(assert) {
+  test('Visiting index with QPs directly does not break', async function(assert) {
     // this does not work - zoning districts are on
     await visit('/?layer-groups=["building-footprints"%2C"commercial-overlays"%2C"subway"%2C"tax-lots"]');
 
     assert.ok(true);
   });
 
-  test('Visiting index with QPs of different types doesn not break', async function(assert) {
+  test('Visiting index with QPs of different types does not break', async function(assert) {
     await visit('/');
-    await click('[data-test-toggle-boroughs]');
-    await click('[data-test-toggle-community-districts]');
 
-    await click('[data-test-grouped-parent="Commercial Districts"]');
-    await click('[data-test-grouped-parent="Manufacturing Districts"]');
-    await click('[data-test-grouped-parent="Residential Districts"]');
+    await click('[data-test-toggle-boroughs] .layer-group-toggle-label'); // this is toggled OFF by default
+    await click('[data-test-toggle-community-districts] .layer-group-toggle-label'); // this is toggled OFF by default
+    await click('[data-test-grouped-parent="Commercial Districts"]'); // this checkbox is checked by default
+    await click('[data-test-grouped-parent="Manufacturing Districts"]'); // this checkbox is checked by default
+    await click('[data-test-grouped-parent="Residential Districts"]'); // this checkbox is checked by default
 
     await click('[data-test-about-close-button]');
 
@@ -36,12 +36,12 @@ module('Acceptance | navigating to qpd url breaks', function(hooks) {
 
     await refresh();
 
-    await percySnapshot('after a refresh, things are applied from previous QPs');
+    await percySnapshot('after a refresh, previous QPs are still applied');
 
     const boroughs = await find('[data-test-toggle-boroughs] input');
     const cds = await find('[data-test-grouped-parent="Commercial Districts"]');
 
-    assert.equal(boroughs.checked, false);
-    assert.equal(cds.checked, false);
+    assert.equal(boroughs.checked, true); // this was turned ON earleir
+    assert.equal(cds.checked, false); // this was UNCHECKED earlier
   });
 });

--- a/tests/integration/components/layer-palette-test.js
+++ b/tests/integration/components/layer-palette-test.js
@@ -1,0 +1,179 @@
+import { module, test, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, pauseTest } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import stubBasicMap from '../../helpers/stub-basic-map';
+import layerGroupsFixtures from '../../../mirage/static-fixtures/layer-groups';
+
+module('Integration | Component | layer-palette', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+  stubBasicMap(hooks);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.set('myAction', function(val) { ... });
+
+  hooks.beforeEach(function() {
+    this.server.get('layer-groups', () => layerGroupsFixtures);
+  });
+
+  test('toggling the Show Land Use Colors checkbox in the layer-palette changes the visibility', async function(assert) {
+    this.layerGroups = await this.owner
+      .lookup('service:store')
+      .findAll('layer-group', { include: 'layers' });
+
+    this.layerGroupsObject = this.layerGroups.reduce(
+      (accumulator, current) => {
+        accumulator[current.get('id')] = current;
+        return accumulator;
+      },
+      {},
+    );
+
+    await render(hbs`
+      {{layer-palette
+        layerGroups=this.layerGroupsObject
+        isDefault=isDefault
+      }}
+    `);
+
+    await click('[data-test-layer-option="land-use-checkbox"]');
+
+    const taxLots = this.layerGroupsObject['tax-lots'];
+    assert.equal(taxLots.visible, true);
+    assert.equal(taxLots.layers.findBy('id', 'pluto-fill').paint['fill-opacity'], 0.5);
+  });
+
+  test('toggling the zoning type checkboxes under Zoning Districts in the layer palette changes which district types are shown', async function(assert) {
+    this.layerGroups = await this.owner
+      .lookup('service:store')
+      .findAll('layer-group', { include: 'layers' });
+
+    this.layerGroupsObject = this.layerGroups.reduce(
+      (accumulator, current) => {
+        accumulator[current.get('id')] = current;
+        return accumulator;
+      },
+      {},
+    );
+
+    this.selectedZoning = [];
+
+    await render(hbs`
+      {{layer-palette
+        selectedZoning=selectedZoning
+        layerGroups=this.layerGroupsObject
+      }}
+    `);
+
+    await click('[data-test-grouped-parent="Commercial Districts"]');
+
+    const zoningDistricts = this.layerGroupsObject['zoning-districts'];
+
+    assert.deepEqual(
+      zoningDistricts.layers.findBy('id', 'zd-fill').style.filter,
+      ['any', ['==', 'primaryzone', 'C1'], ['==', 'primaryzone', 'C2'], ['==', 'primaryzone', 'C3'], ['==', 'primaryzone', 'C4'], ['==', 'primaryzone', 'C5'], ['==', 'primaryzone', 'C6'], ['==', 'primaryzone', 'C7'], ['==', 'primaryzone', 'C8']],
+    );
+  });
+
+  test('toggling the commercial overlay type checkboxes under Commercial Overlays in the layer palette changes which types are shown', async function(assert) {
+    this.layerGroups = await this.owner
+      .lookup('service:store')
+      .findAll('layer-group', { include: 'layers' });
+
+    this.layerGroupsObject = this.layerGroups.reduce(
+      (accumulator, current) => {
+        accumulator[current.get('id')] = current;
+        return accumulator;
+      },
+      {},
+    );
+
+    this.selectedOverlays = [];
+
+    await render(hbs`
+      {{layer-palette
+        selectedOverlays=selectedOverlays
+        layerGroups=this.layerGroupsObject
+      }}
+    `);
+
+    await click('[data-test-grouped-parent="C1-1 through C1-5"]');
+
+    const commercialOverlays = this.layerGroupsObject['commercial-overlays'];
+
+    assert.deepEqual(
+      commercialOverlays.layers.findBy('id', 'co').style.filter,
+      ['any', ['==', 'overlay', 'C1-1'], ['==', 'overlay', 'C1-2'], ['==', 'overlay', 'C1-3'], ['==', 'overlay', 'C1-4'], ['==', 'overlay', 'C1-5']],
+    );
+  });
+
+  test('toggling aerials changes the year shown', async function(assert) {
+    this.layerGroups = await this.owner
+      .lookup('service:store')
+      .findAll('layer-group', { include: 'layers' });
+
+    this.layerGroupsObject = this.layerGroups.reduce(
+      (accumulator, current) => {
+        accumulator[current.get('id')] = current;
+        return accumulator;
+      },
+      {},
+    );
+
+    await render(hbs`
+      {{layer-palette
+        layerGroups=this.layerGroupsObject
+        isDefault=isDefault
+      }}
+    `);
+
+    await click('[data-test-toggle-aerials] .layer-group-toggle-label');
+    const aerialsLayer = this.layerGroupsObject.aerials;
+    assert.equal(aerialsLayer.visible, true); // check that toggling the layer makes it visible
+
+    await click('[data-test-radio="aerials-2008"]');
+    assert.equal(aerialsLayer.layers.findBy('id', 'aerials-2008').visibility, true); // clicking on the new radio button changes the visibility
+  });
+
+  // reset map button is broken as of now, will fix in another branch and return to this test
+  skip('clicking reset map button resets to all of default layers', async function(assert) {
+    this.layerGroups = await this.owner
+      .lookup('service:store')
+      .findAll('layer-group', { include: 'layers' });
+
+    this.layerGroupsObject = this.layerGroups.reduce(
+      (accumulator, current) => {
+        accumulator[current.get('id')] = current;
+        return accumulator;
+      },
+      {},
+    );
+
+    this.selectedOverlays = [];
+    this.selectedZoning = [];
+
+    await render(hbs`
+      {{layer-palette
+        selectedZoning=selectedZoning
+        selectedOverlays=selectedOverlays
+        layerGroups=this.layerGroupsObject
+        isDefault=isDefault
+      }}
+    `);
+
+    await click('[data-test-grouped-parent="Commercial Districts"]'); // under Zoning Districts
+    await click('[data-test-grouped-parent="C1-1 through C1-5"]'); // under Commercial Overlays
+    await click('[data-test-toggle-aerials] .layer-group-toggle-label'); // Aerial Imagery
+    const zoningDistricts = this.layerGroupsObject['zoning-districts'];
+    const commercialOverlays = this.layerGroupsObject['commercial-overlays'];
+    const aerialsLayer = this.layerGroupsObject.aerials;
+
+    await click('[data-test-reset-map-button]');
+    await pauseTest();
+    assert.deepEqual(zoningDistricts.layers.findBy('id', 'zd-fill').style.filter, []); // reset to none
+    assert.deepEqual(commercialOverlays.layers.findBy('id', 'co').style.filter, []); // reset to none
+    assert.equal(aerialsLayer.visible, false); // toggle to false
+  });
+});

--- a/tests/integration/components/map-measurement-tools-test.js
+++ b/tests/integration/components/map-measurement-tools-test.js
@@ -2,25 +2,24 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import stubBasicMap from '../../helpers/stub-basic-map';
 
 module('Integration | Component | map-measurement-tools', function(hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
+  stubBasicMap(hooks);
 
   test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
-    await render(hbs`<MapMeasurementTools />`);
-
-    assert.equal(this.element.textContent.trim(), '');
-
-    // Template block usage:
     await render(hbs`
-      <MapMeasurementTools>
-        template block text
-      </MapMeasurementTools>
+      {{#map-measurement-tools
+        map=map
+        draw=this.draw as |measurement|
+      }}
+
+      {{/map-measurement-tools}}
     `);
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.ok(this.element);
   });
 });


### PR DESCRIPTION
Note: I added a test (that is skipped for now) for the Reset Map button at the bottom of the layers palette. This button is broken right now (issue #798 ). This test can be used while fixing that bug in another branch.

Closes #849 
