### PR TITLE
Refactor main-map; fix routing bug with redirect

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -1,13 +1,11 @@
 import Component from '@ember/component';
 import mapboxgl from 'mapbox-gl';
-import numeral from 'numeral';
 
 import { inject as service } from '@ember/service';
 import EmberObject, { computed, action } from '@ember/object';
 import { classNames } from '@ember-decorators/component';
 import { alias } from '@ember/object/computed';
 
-import drawStyles from '../layers/draw-styles';
 import bblDemux from '../utils/bbl-demux';
 import Geometric from '../mixins/geometric';
 import drawnFeatureLayers from '../layers/drawn-feature';
@@ -61,14 +59,6 @@ export default class MainMap extends Component {
 
   sourcesLoaded = true;
 
-  measurementUnitType = 'standard';
-
-  drawnMeasurements = null;
-
-  measurementMenuOpen = false;
-
-  drawToolsOpen = false;
-
   cartoSources = [];
 
   drawnFeatureLayers = drawnFeatureLayers;
@@ -78,12 +68,6 @@ export default class MainMap extends Component {
   highlightedLayerId = null;
 
   highlightedLotLayer = highlightedLotLayer;
-
-  draw = null;
-
-  didStartDraw = false;
-
-  drawDidRender = false;
 
   @computed('layerGroupsObject')
   get mapConfig() {
@@ -161,7 +145,6 @@ export default class MainMap extends Component {
   selectedFillLayer = selectedFillLayer;
 
   selectedLineLayer = selectedLineLayer;
-
 
   @action
   adjustBuildingsLayer(visible) {
@@ -245,124 +228,6 @@ export default class MainMap extends Component {
   }
 
   @action
-  async startDraw(type) {
-    this.set('didStartDraw', true);
-    const draw = this.get('draw') || await import('mapbox-gl-draw')
-      .then(({ default: MapboxDraw }) => new MapboxDraw({
-        displayControlsDefault: false,
-        styles: drawStyles,
-      }));
-    this.set('draw', draw);
-    const drawMode = type === 'line' ? 'draw_line_string' : 'draw_polygon';
-    const { mainMap } = this;
-    if (mainMap.get('drawMode')) {
-      draw.deleteAll();
-    } else {
-      mainMap.mapInstance.addControl(draw);
-      this.set('mainMap.drawnFeature', null);
-      this.set('drawnMeasurements', null);
-    }
-    mainMap.set('drawMode', drawMode);
-    draw.changeMode(drawMode);
-  }
-
-  @action
-  clearDraw() {
-    const draw = this.get('draw');
-    const { mainMap } = this;
-    if (mainMap.get('drawMode')) {
-      mainMap.mapInstance.removeControl(draw);
-    }
-
-    mainMap.set('drawMode', null);
-    this.set('mainMap.drawnFeature', null);
-    this.set('drawnMeasurements', null);
-  }
-
-  @action
-  handleDrawCreate(e) {
-    const draw = this.get('draw');
-    this.set('mainMap.drawnFeature', e.features[0].geometry);
-    setTimeout(() => {
-      if (!this.mainMap.isDestroyed && !this.mainMap.isDestroying) {
-        this.mainMap.mapInstance.removeControl(draw);
-        this.mainMap.set('drawMode', null);
-      }
-    }, 100);
-  }
-
-  @action
-  async handleMeasurement() {
-    this.set('drawDidRender', true);
-    const draw = this.get('draw');
-    // should log both metric and standard display strings for the current drawn feature
-    const { features } = draw.getAll();
-
-    if (features.length > 0) {
-      const feature = features[0];
-      // metric calculation
-
-      // lazy load these deps
-      const { default: area } = await import('@turf/area');
-      const { default: lineDistance } = await import('@turf/line-distance');
-
-      const drawnLength = (lineDistance(feature) * 1000); // meters
-      const drawnArea = area(feature); // square meters
-
-      let metricUnits = 'm';
-      let metricFormat = '0,0';
-      let metricMeasurement;
-
-      let standardUnits = 'feet';
-      let standardFormat = '0,0';
-      let standardMeasurement;
-
-      if (drawnLength > drawnArea) { // user is drawing a line
-        metricMeasurement = drawnLength;
-        if (drawnLength >= 1000) { // if over 1000 meters, upgrade metric
-          metricMeasurement = drawnLength / 1000;
-          metricUnits = 'km';
-          metricFormat = '0.00';
-        }
-
-        standardMeasurement = drawnLength * 3.28084;
-        if (standardMeasurement >= 5280) { // if over 5280 feet, upgrade standard
-          standardMeasurement /= 5280;
-          standardUnits = 'mi';
-          standardFormat = '0.00';
-        }
-      } else { // user is drawing a polygon
-        metricUnits = 'm²';
-        metricFormat = '0,0';
-        metricMeasurement = drawnArea;
-
-        standardUnits = 'ft²';
-        standardFormat = '0,0';
-        standardMeasurement = drawnArea * 10.7639;
-
-        if (drawnArea >= 1000000) { // if over 1,000,000 meters, upgrade metric
-          metricMeasurement = drawnArea / 1000000;
-          metricUnits = 'km²';
-          metricFormat = '0.00';
-        }
-
-        if (standardMeasurement >= 27878400) { // if over 27878400 sf, upgrade standard
-          standardMeasurement /= 27878400;
-          standardUnits = 'mi²';
-          standardFormat = '0.00';
-        }
-      }
-
-      const drawnMeasurements = {
-        metric: `${numeral(metricMeasurement).format(metricFormat)} ${metricUnits}`,
-        standard: `${numeral(standardMeasurement).format(standardFormat)} ${standardUnits}`,
-      };
-
-      this.set('drawnMeasurements', drawnMeasurements);
-    }
-  }
-
-  @action
   mapLoading(data) {
     const localConfig = this.mapConfig;
     const sourceIds = localConfig.mapBy('id');
@@ -379,11 +244,6 @@ export default class MainMap extends Component {
         this.set('loading', true);
       }
     }
-  }
-
-  @action
-  handleUnitsToggle(type) {
-    this.set('measurementUnitType', type);
   }
 
   @action

--- a/app/components/map-measurement-tools.js
+++ b/app/components/map-measurement-tools.js
@@ -1,0 +1,159 @@
+import Component from '@ember/component';
+import numeral from 'numeral';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import drawStyles from '../layers/draw-styles';
+
+export default class MapMeasurementToolsComponent extends Component {
+  @service
+  mainMap;
+
+  measurementUnitType = 'standard';
+
+  drawnMeasurements = null;
+
+  measurementMenuOpen = false;
+
+  drawToolsOpen = false;
+
+  draw = null;
+
+  didStartDraw = false;
+
+  drawDidRender = false;
+
+  drawnFeature = {
+    type: 'Feature',
+    geometry: null,
+  };
+
+  @action
+  async startDraw(type) {
+    this.set('didStartDraw', true);
+    const draw = this.get('draw') || await import('mapbox-gl-draw')
+      .then(({ default: MapboxDraw }) => new MapboxDraw({
+        displayControlsDefault: false,
+        styles: drawStyles,
+      }));
+    this.set('draw', draw);
+    const drawMode = type === 'line' ? 'draw_line_string' : 'draw_polygon';
+    const { mainMap } = this;
+    if (mainMap.get('drawMode')) {
+      draw.deleteAll();
+    } else {
+      mainMap.mapInstance.addControl(draw);
+      this.set('drawnFeature', null);
+      this.set('drawnMeasurements', null);
+    }
+    mainMap.set('drawMode', drawMode);
+    draw.changeMode(drawMode);
+  }
+
+  @action
+  clearDraw() {
+    const draw = this.get('draw');
+    const { mainMap } = this;
+    if (mainMap.get('drawMode')) {
+      mainMap.mapInstance.removeControl(draw);
+    }
+
+    mainMap.set('drawMode', null);
+    this.set('drawnFeature', null);
+    this.set('drawnMeasurements', null);
+  }
+
+  @action
+  handleDrawCreate(e) {
+    const draw = this.get('draw');
+    this.set('drawnFeature', e.features[0].geometry);
+    setTimeout(() => {
+      if (!this.mainMap.isDestroyed && !this.mainMap.isDestroying) {
+        this.mainMap.mapInstance.removeControl(draw);
+        this.mainMap.set('drawMode', null);
+      }
+    }, 100);
+  }
+
+  @action
+  async handleMeasurement() {
+    this.set('drawDidRender', true);
+    const draw = this.get('draw');
+    // should log both metric and standard display strings for the current drawn feature
+    const { features } = draw.getAll();
+
+    if (features.length > 0) {
+      const feature = features[0];
+
+      const drawnMeasurements = await calculateMeasurements(feature); //eslint-disable-line
+
+      this.set('drawnMeasurements', drawnMeasurements);
+    }
+  }
+
+  @action
+  handleUnitsToggle(type) {
+    this.set('measurementUnitType', type);
+  }
+}
+
+async function calculateMeasurements(feature) {
+  // metric calculation
+
+  // lazy load these deps
+  const { default: area } = await import('@turf/area');
+  const { default: lineDistance } = await import('@turf/line-distance');
+
+  const drawnLength = (lineDistance(feature) * 1000); // meters
+  const drawnArea = area(feature); // square meters
+
+  let metricUnits = 'm';
+  let metricFormat = '0,0';
+  let metricMeasurement;
+
+  let standardUnits = 'feet';
+  let standardFormat = '0,0';
+  let standardMeasurement;
+
+  if (drawnLength > drawnArea) { // user is drawing a line
+    metricMeasurement = drawnLength;
+    if (drawnLength >= 1000) { // if over 1000 meters, upgrade metric
+      metricMeasurement = drawnLength / 1000;
+      metricUnits = 'km';
+      metricFormat = '0.00';
+    }
+
+    standardMeasurement = drawnLength * 3.28084;
+    if (standardMeasurement >= 5280) { // if over 5280 feet, upgrade standard
+      standardMeasurement /= 5280;
+      standardUnits = 'mi';
+      standardFormat = '0.00';
+    }
+  } else { // user is drawing a polygon
+    metricUnits = 'm²';
+    metricFormat = '0,0';
+    metricMeasurement = drawnArea;
+
+    standardUnits = 'ft²';
+    standardFormat = '0,0';
+    standardMeasurement = drawnArea * 10.7639;
+
+    if (drawnArea >= 1000000) { // if over 1,000,000 meters, upgrade metric
+      metricMeasurement = drawnArea / 1000000;
+      metricUnits = 'km²';
+      metricFormat = '0.00';
+    }
+
+    if (standardMeasurement >= 27878400) { // if over 27878400 sf, upgrade standard
+      standardMeasurement /= 27878400;
+      standardUnits = 'mi²';
+      standardFormat = '0.00';
+    }
+  }
+
+  const drawnMeasurements = {
+    metric: `${numeral(metricMeasurement).format(metricFormat)} ${metricUnits}`,
+    standard: `${numeral(standardMeasurement).format(standardFormat)} ${standardUnits}`,
+  };
+
+  return drawnMeasurements;
+}

--- a/app/services/main-map.js
+++ b/app/services/main-map.js
@@ -38,18 +38,7 @@ export default class MainMapService extends Service {
 
   currentAddress = null;
 
-  drawnFeature = null;
-
   routeIntentIsNested = false;
-
-  @computed('drawnFeature')
-  get drawnFeatureSource() {
-    const feature = this.get('drawnFeature');
-    return {
-      type: 'geojson',
-      data: feature,
-    };
-  }
 
   @computed('currentAddress')
   get addressSource() {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -73,3 +73,6 @@
     {{outlet}}
   </div>
 </div>
+
+
+{{outlet}}

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -62,122 +62,45 @@
     {{/mapbox-gl-source}}
   {{/if}}
 
-  {{#if mainMap.drawnFeature}}
-    {{#mapbox-gl-source
-      map=map.instance
-      sourceId='drawn-feature'
-      options=mainMap.drawnFeatureSource as |source|}}
-      {{source.layer layer=drawnFeatureLayers.line before='place_other'}}
-      {{#if (eq mainMap.drawnFeature.type 'Polygon')}}
-        {{source.layer layer=drawnFeatureLayers.fill before='place_other'}}
-      {{/if}}
-    {{/mapbox-gl-source}}
-  {{/if}}
-
   {{#if mainMap.currentAddress}}
     {{#map.source sourceId='currentAddress' options=mainMap.addressSource as |source|}}
       {{source.layer layer=mainMap.pointLayer}}
     {{/map.source}}
   {{/if}}
 
+  {{#map-measurement-tools
+    map=map.instance
+    draw=this.draw as |measurement|
+  }}
+    {{#if measurement.feature}}
+      {{#mapbox-gl-source
+        map=map.instance
+        sourceId='drawn-feature'
+        options=(hash
+          type='geojson'
+          data=measurement.feature
+        ) as |source|
+      }}
+        {{source.layer
+          layer=drawnFeatureLayers.line
+          before='place_other'
+        }}
+        {{#if (eq mainMap.drawnFeature.type 'Polygon')}}
+          {{source.layer
+            layer=drawnFeatureLayers.fill
+            before='place_other'
+          }}
+        {{/if}}
+      {{/mapbox-gl-source}}
+    {{/if}}
+  {{/map-measurement-tools}}
+
   {{mapbox-gl-on 'data' (action 'mapLoading') eventSource=map.instance}}
-  {{mapbox-gl-on 'draw.create' (action 'handleDrawCreate') eventSource=map.instance}}
-  {{mapbox-gl-on 'draw.render' (action 'handleMeasurement') eventSource=map.instance}}
 {{/mapbox/basic-map}}
 
-<div class="draw-tools hide-for-print">
-  <label>
-    <span
-      data-test-button="begin-measure"
-      class="hide-for-large"
-      {{action (mut drawToolsOpen) (not drawToolsOpen)}}
-    >
-      {{#if drawToolsOpen}}
-        {{fa-icon 'chevron-left'}}
-      {{else}}
-        {{fa-icon 'pen'}}
-      {{/if}}
-    </span>
-    <span class="show-for-large">Measure</span>
-  </label>
-  <button
-    data-test-button="measure-tool-line"
-    class="draw-tool draw-tool--line
-      {{unless drawToolsOpen 'show-for-large'}}
-      {{if (eq mainMap.drawMode 'draw_line_string') 'active'}}"
-    onclick={{action 'startDraw' 'line'}}
-  >
-    {{#if (and didStartDraw (not drawDidRender) (not draw))}}
-      {{fa-icon 'spinner'}}
-    {{else}}
-      <span class="icon distance"></span>
-    {{/if}}
-  </button>
-
-  <button
-    data-test-button="measure-tool-polygon"
-    class="draw-tool draw-tool--polygon
-      {{unless drawToolsOpen 'show-for-large'}}
-      {{if (eq mainMap.drawMode 'draw_polygon') 'active'}}"
-    onclick={{action 'startDraw' 'polygon'}}
-  >
-    {{#if (and didStartDraw (not drawDidRender) (not draw))}}
-      {{fa-icon 'spinner'}}
-    {{else}}
-      <span class="icon polygon"></span>
-    {{/if}}
-  </button>
-  {{#if drawnMeasurements}}
-    <button
-      data-test-button="measure-tool-close"
-      class="draw-tool draw-tool--clear"
-      onclick={{action 'clearDraw'}}
-    >
-      {{fa-icon "times"}}
-    </button>
-  {{/if}}
-</div>
-{{#if drawnMeasurements}}
-  <div class="draw-measurement">
-    <div data-test-measure="value">
-      {{#if (eq measurementUnitType 'standard')}} 
-        {{drawnMeasurements.standard}}
-      {{else}}
-        {{drawnMeasurements.metric}}
-      {{/if}}
-    </div>
-    <span
-      data-test-measure="unit-menu"
-      class="draw-measurement-menu-button"
-        {{action (mut measurementMenuOpen) (not measurementMenuOpen)}}
-    >
-      {{#if measurementMenuOpen}}
-        {{fa-icon 'caret-down'}}
-      {{else}}
-        {{fa-icon 'caret-up'}}
-      {{/if}}
-      {{#if measurementMenuOpen}}
-        <span class="draw-measurement-menu">
-          <button
-            data-tests-measure="unit-standard"
-            class="button tiny gray"
-            onclick={{action 'handleUnitsToggle' 'standard'}}
-          >
-            {{fa-icon (if (eq measurementUnitType 'standard') 'dot-circle-o' 'circle-thin') class=(if (eq measurementUnitType 'metric') 'medium-gray')}} Standard
-          </button>
-          <button
-            data-tests-measure="unit-metric"
-            class="button tiny gray"
-            onclick={{action 'handleUnitsToggle' 'metric'}}
-          >
-            {{fa-icon (if (eq measurementUnitType 'metric') 'dot-circle-o' 'circle-thin') class=(if (eq measurementUnitType 'standard') 'medium-gray')}} Metric
-          </button>
-        </span>
-      {{/if}}
-    </span>
-  </div>
-{{/if}}
-
+{{!--
+  TODO: Geolocate Feature -> Move into separate component
+--}}
 {{#unless findMeDismissed}}
   <div class="find-me">
     <button {{action 'locateMe'}} class="button hide-for-medium hide-for-print no-margin">Locate&nbsp;Me</button>

--- a/app/templates/components/map-measurement-tools.hbs
+++ b/app/templates/components/map-measurement-tools.hbs
@@ -1,0 +1,98 @@
+{{yield (hash feature=drawnFeature)}}
+
+{{mapbox-gl-on 'draw.create' (action 'handleDrawCreate') eventSource=map}}
+{{mapbox-gl-on 'draw.render' (action 'handleMeasurement') eventSource=map}}
+
+{{!-- Measurement --}}
+<div class="draw-tools hide-for-print">
+  <label>
+    <span
+      data-test-button="begin-measure"
+      class="hide-for-large"
+        {{action (mut drawToolsOpen) (not drawToolsOpen)}}
+    >
+      {{#if drawToolsOpen}}
+        {{fa-icon 'chevron-left'}}
+      {{else}}
+        {{fa-icon 'pen'}}
+      {{/if}}
+    </span>
+    <span class="show-for-large">Measure</span>
+  </label>
+  <button
+    data-test-button="measure-tool-line"
+    class="draw-tool draw-tool--line
+      {{unless drawToolsOpen 'show-for-large'}}
+      {{if (eq mainMap.drawMode 'draw_line_string') 'active'}}"
+    onclick={{action 'startDraw' 'line'}}
+  >
+    {{#if (and didStartDraw (not drawDidRender) (not draw))}}
+      {{fa-icon 'spinner'}}
+    {{else}}
+      <span class="icon distance"></span>
+    {{/if}}
+  </button>
+
+  <button
+    data-test-button="measure-tool-polygon"
+    class="draw-tool draw-tool--polygon
+      {{unless drawToolsOpen 'show-for-large'}}
+      {{if (eq mainMap.drawMode 'draw_polygon') 'active'}}"
+    onclick={{action 'startDraw' 'polygon'}}
+  >
+    {{#if (and didStartDraw (not drawDidRender) (not draw))}}
+      {{fa-icon 'spinner'}}
+    {{else}}
+      <span class="icon polygon"></span>
+    {{/if}}
+  </button>
+  {{#if drawnMeasurements}}
+    <button
+      data-test-button="measure-tool-close"
+      class="draw-tool draw-tool--clear"
+      onclick={{action 'clearDraw'}}
+    >
+      {{fa-icon "times"}}
+    </button>
+  {{/if}}
+</div>
+{{#if drawnMeasurements}}
+  <div class="draw-measurement">
+    <div data-test-measure="value">
+      {{#if (eq measurementUnitType 'standard')}} 
+        {{drawnMeasurements.standard}}
+      {{else}}
+        {{drawnMeasurements.metric}}
+      {{/if}}
+    </div>
+    <span
+      data-test-measure="unit-menu"
+      class="draw-measurement-menu-button"
+        {{action (mut measurementMenuOpen) (not measurementMenuOpen)}}
+    >
+      {{#if measurementMenuOpen}}
+        {{fa-icon 'caret-down'}}
+      {{else}}
+        {{fa-icon 'caret-up'}}
+      {{/if}}
+      {{#if measurementMenuOpen}}
+        <span class="draw-measurement-menu">
+          <button
+            data-tests-measure="unit-standard"
+            class="button tiny gray"
+            onclick={{action 'handleUnitsToggle' 'standard'}}
+          >
+            {{fa-icon (if (eq measurementUnitType 'standard') 'dot-circle-o' 'circle-thin') class=(if (eq measurementUnitType 'metric') 'medium-gray')}} Standard
+          </button>
+          <button
+            data-tests-measure="unit-metric"
+            class="button tiny gray"
+            onclick={{action 'handleUnitsToggle' 'metric'}}
+          >
+            {{fa-icon (if (eq measurementUnitType 'metric') 'dot-circle-o' 'circle-thin') class=(if (eq measurementUnitType 'standard') 'medium-gray')}} Metric
+          </button>
+        </span>
+      {{/if}}
+    </span>
+  </div>
+{{/if}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,16 @@ const babelPlugin = require('ember-auto-import/babel-plugin');
 
 module.exports = (defaults) => {
   const app = new EmberApp(defaults, {
+    'ember-ast-hot-load': {
+      helpers: [
+        'bbl-demux',
+        'carto-download-link',
+        'extract-layer-stops-for',
+        'numeral-format',
+        'to-title-case',
+      ],
+      enabled: true,
+    },
     'ember-cli-babel': {
       includePolyfill: true,
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-plugin-transform-object-rest-spread": "^7.0.0-beta.3",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-clean-css": "^2.0.1",
+    "ember-ast-hot-load": "0.0.80",
     "ember-async-await-helper": "0.1.0",
     "ember-auto-import": "^1.2.19",
     "ember-clean-project": "1.0.1",

--- a/tests/acceptance/navigating-to-qpd-url-breaks-test.js
+++ b/tests/acceptance/navigating-to-qpd-url-breaks-test.js
@@ -34,6 +34,7 @@ module('Acceptance | navigating to qpd url breaks', function(hooks) {
 
     // await percySnapshot('qp test: visit index, change some things');
 
+    // the refresh here resets the context, requiring re-mocking
     await refresh();
 
     // await percySnapshot('after a refresh, things are applied from previous QPs');

--- a/tests/acceptance/root-query-params-honored-after-redirect-test.js
+++ b/tests/acceptance/root-query-params-honored-after-redirect-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
+
+module('Acceptance | root query params honored after redirect', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    this.server.post('layer-groups', () => layerGroupsFixtures);
+  });
+
+  test('visiting site with query params on root are honored after the redirect to about', async function(assert) {
+    await visit('/?layer-groups=%5B%22street-centerlines%22%2C%22tax-lots%22%5D');
+
+    assert.equal(currentURL(), '/about?layer-groups=%5B%22street-centerlines%22%2C%22tax-lots%22%5D');
+  });
+});

--- a/tests/helpers/stub-basic-map.js
+++ b/tests/helpers/stub-basic-map.js
@@ -110,6 +110,7 @@ const createMapStub = function(testContext) {
   return BasicMapStub;
 };
 
+// TODO: extract out the stub registration so that it can be used in other contexts
 export default function(hooks) {
   hooks.beforeEach(async function() {
     this.owner.register('component:mapbox/basic-map', createMapStub(this));

--- a/tests/integration/components/main-map-test.js
+++ b/tests/integration/components/main-map-test.js
@@ -176,6 +176,14 @@ module('Integration | Component | main-map', function(hooks) {
         getAll: () => ({ features: this.map.features }),
       };
 
+      let lastSource = '';
+      this.map = {
+        ...this.map,
+        addSource(source) {
+          lastSource = source;
+        },
+      };
+
       await render(hbs`
         {{main-map
           layerGroups=this.layerGroups
@@ -202,6 +210,9 @@ module('Integration | Component | main-map', function(hooks) {
       const measurement = find('[data-test-measure="value"]').textContent.trim();
 
       assert.equal(measurement, '97.74 mi');
+
+      // make sure the drawn source gets added to map
+      assert.equal(lastSource, 'drawn-feature');
 
       await click('[data-test-button="measure-tool-close"]');
     });

--- a/tests/integration/components/map-measurement-tools-test.js
+++ b/tests/integration/components/map-measurement-tools-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { MAPBOX_GL_DEFAULTS } from '../../helpers/stub-basic-map';
+
+module('Integration | Component | map-measurement-tools', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.map = {
+      ...MAPBOX_GL_DEFAULTS,
+    };
+
+    // Template block usage:
+    await render(hbs`
+      <MapMeasurementTools @map={{this.map}}>
+        template block text
+      </MapMeasurementTools>
+    `);
+
+    assert.ok(this.element);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,7 +1955,7 @@ babel-plugin-debug-macros@^0.3.0:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-ember-modules-api-polyfill@^2.3.0, babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.8.0:
+babel-plugin-ember-modules-api-polyfill@>=2.0.1, babel-plugin-ember-modules-api-polyfill@^2.3.0, babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.8.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
   dependencies:
@@ -3016,7 +3016,7 @@ broccoli-stew@^1.5.0:
     symlink-or-copy "^1.2.0"
     walk-sync "^0.3.0"
 
-broccoli-stew@^2.0.0, broccoli-stew@^2.1.0:
+broccoli-stew@^2.0.0, broccoli-stew@^2.0.1, broccoli-stew@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-2.1.0.tgz#ba73add17fda3b9b01d8cfb343a8b613b7136a0a"
   dependencies:
@@ -4361,6 +4361,15 @@ ember-ast-helpers@0.3.5:
     "@glimmer/compiler" "^0.27.0"
     "@glimmer/syntax" "^0.27.0"
 
+ember-ast-hot-load@0.0.80:
+  version "0.0.80"
+  resolved "https://registry.yarnpkg.com/ember-ast-hot-load/-/ember-ast-hot-load-0.0.80.tgz#45028f4c627c72870435c85bac0534a0fe039007"
+  dependencies:
+    babel-plugin-ember-modules-api-polyfill ">=2.0.1"
+    broccoli-stew "^2.0.1"
+    ember-cli-babel ">=6.6.0"
+    ember-cli-htmlbars "*"
+
 ember-async-await-helper@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/ember-async-await-helper/-/ember-async-await-helper-0.1.0.tgz#30a0b0a215c1337be78b7a56017646bd917f2b97"
@@ -4472,25 +4481,7 @@ ember-cli-babel@6.14.1:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
-  dependencies:
-    amd-name-resolver "1.2.0"
-    babel-plugin-debug-macros "^0.2.0-beta.6"
-    babel-plugin-ember-modules-api-polyfill "^2.6.0"
-    babel-plugin-transform-es2015-modules-amd "^6.24.0"
-    babel-polyfill "^6.26.0"
-    babel-preset-env "^1.7.0"
-    broccoli-babel-transpiler "^6.5.0"
-    broccoli-debug "^0.6.4"
-    broccoli-funnel "^2.0.0"
-    broccoli-source "^1.1.0"
-    clone "^2.0.0"
-    ember-cli-version-checker "^2.1.2"
-    semver "^5.5.0"
-
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.1.4, ember-cli-babel@^7.2.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@>=6.6.0, ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.1.4, ember-cli-babel@^7.2.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
   dependencies:
@@ -4514,6 +4505,24 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cl
     ember-cli-babel-plugin-helpers "^1.1.0"
     ember-cli-version-checker "^2.1.2"
     ensure-posix-path "^1.0.2"
+    semver "^5.5.0"
+
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
 ember-cli-broccoli-sane-watcher@^3.0.0:
@@ -4648,6 +4657,15 @@ ember-cli-htmlbars-inline-precompile@^2.1.0:
     heimdalljs-logger "^0.1.9"
     silent-error "^1.1.0"
 
+ember-cli-htmlbars@*, ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-3.0.1.tgz#01e21f0fd05e0a6489154f26614b1041769e3e58"
+  dependencies:
+    broccoli-persistent-filter "^1.4.3"
+    hash-for-dep "^1.2.3"
+    json-stable-stringify "^1.0.0"
+    strip-bom "^3.0.0"
+
 ember-cli-htmlbars@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.5.tgz#65be9678b274b5e7861d7f75c188780af7ef9d13"
@@ -4661,15 +4679,6 @@ ember-cli-htmlbars@^1.1.1:
 ember-cli-htmlbars@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz#b5a105429a6bce4f7c9c97b667e3b8926e31397f"
-  dependencies:
-    broccoli-persistent-filter "^1.4.3"
-    hash-for-dep "^1.2.3"
-    json-stable-stringify "^1.0.0"
-    strip-bom "^3.0.0"
-
-ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-3.0.1.tgz#01e21f0fd05e0a6489154f26614b1041769e3e58"
   dependencies:
     broccoli-persistent-filter "^1.4.3"
     hash-for-dep "^1.2.3"


### PR DESCRIPTION
Addresses #805

- This PR fixes a bug where direct, query-param'd links to main root of the app were redirecting to /about _without_ query params. Please review`services/layer-groups.js`
- Tests are added to demonstrate bug and increase coverage in main-map component
- As a rider, this PR splits out the measurement tools part of the map - specifically, that component is called map-measurement-tools. It shouldn't receive a thorough code review as it's largely moving code around. I would like input on the general direction (splitting it out into a component, the name of that component, using contextual params, etc). 


