### PR TITLE
784 address qp bug with print

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -3,15 +3,23 @@ import DS from 'ember-data';
 
 export default DS.JSONSerializer.extend({
   normalizeFindRecordResponse(store, primaryModelClass, payload, queryId, requestType) {
-    const [feature] = payload.features;
-    const { id } = feature.properties;
-    const { geometry } = feature;
-    const json = assign(feature.properties, { id, geometry });
+    let newPayload = payload;
+    let newQueryId = queryId;
+
+    if (payload.features) {
+      const [feature] = payload.features;
+
+      const { id } = feature.properties;
+      newQueryId = id;
+
+      const { geometry } = feature;
+      newPayload = assign(feature.properties, { id, geometry });
+    }
 
     return this._super(store,
       primaryModelClass,
-      json,
-      id,
+      newPayload,
+      newQueryId,
       requestType);
   },
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -4,7 +4,13 @@
   as |banner|
 }}
   {{#banner.title}}
-    {{#link-to 'index' classNames='site-title' click=(action resetQueryParams)}}ZoLa <small class="site-subtitle show-for-medium">N<span class="show-for-large">ew </span>Y<span class="show-for-large">ork </span>C<span class="show-for-large">ity</span>&rsquo;s Zoning &amp; Land Use Map</small>{{/link-to}}
+    {{#link-to 'index'
+      (query-params print=false)
+      data-test-link-to="index"
+      classNames='site-title'
+    }}
+      ZoLa <small class="site-subtitle show-for-medium">N<span class="show-for-large">ew </span>Y<span class="show-for-large">ork </span>C<span class="show-for-large">ity</span>&rsquo;s Zoning &amp; Land Use Map</small>
+    {{/link-to}}
   {{/banner.title}}
   {{#banner.nav}}
     <ul class="menu vertical large-horizontal">

--- a/tests/acceptance/user-can-navigate-away-from-print-via-header-test.js
+++ b/tests/acceptance/user-can-navigate-away-from-print-via-header-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+import { visit, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
+
+module('Acceptance | user can navigate away from print via header', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    this.server.post('layer-groups', () => layerGroupsFixtures);
+  });
+
+  test('user can navigate away from print via header', async function(assert) {
+    // if you visit the site
+    await visit('/');
+
+    // when you click print, then click back
+    await click('[data-test-map-print-button=""]');
+
+    await click('[data-test-link-to="index"]');
+
+    // then the site still works!
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
Addresses #784 by removing the click handler for banner link-to, which was calling currently-broken "reset query params" functionality. 

This also explicitly turns off the print QP when navigating to index.

Includes a test for behavior.

Cleans up the nasty application serializer for 🏕 