### PR TITLE
854: QuickFix, remove search as an option from mixin while search is deactivated

### DIFF
--- a/app/mixins/update-selection-all-features.js
+++ b/app/mixins/update-selection-all-features.js
@@ -11,7 +11,7 @@ import { inject as service } from '@ember/service';
 export default Mixin.create({
   mainMap: service(),
   afterModel({ taskInstance }, transition) {
-    if (transition.queryParams.search === 'true') {
+    if (transition.queryParams && transition.queryParams.search === 'true') {
       this.waitToFitBounds.perform(taskInstance);
     }
   },


### PR DESCRIPTION
While search is deactivated for zoning districts, commercial overlays, zoning map amendments, special purpose districts, and special purpose subdistricts, this PR removes the `search` option from a Mixin that determines search vs. click layer interactivity. 

The deactivation of search for these layers was causing clicking on a layer to not transition to the appropriate route--this should remove that error for now. 

This is a quick fix and will be reverted once search is working again. 

Addresses #854 