### PR TITLE
Add failing behavior grid tests

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -19,7 +19,7 @@ if (typeof Ember.Test === 'undefined') {
   Ember.Test = {
     registerWaiter() {
 
-    }
+    },
   };
 }
 /* eslint-enable ember-suave/no-direct-property-access, no-undef */

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -42,6 +42,3 @@
     {{outlet}}
   </div>
 </div>
-
-
-{{outlet}}

--- a/app/templates/commercial-overlay.hbs
+++ b/app/templates/commercial-overlay.hbs
@@ -21,7 +21,7 @@
 
     <p>Unless otherwise specified on the zoning maps, the depth of C1 overlay districts, measured from the nearest street, is 200 feet for C1-1 districts, 150 feet for C1-2, C1-3, C2-1, C2-2 and C2-3 districts, and 100 feet for C1-4, C1-5, C2-4 and C2-5 districts. When mapped on the long dimension of a block, commercial overlays extend to the midpoint of that block.</p>
     <p><a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/c1-c2-overlays.page" target="_blank">{{fa-icon 'external-link-alt'}} Learn More</a></p>
-    <button {{action "fitBounds"}} class="button tiny hollow">Fit map to all {{model.value.id}} districts</button>
+    <button data-test-button="fit-bounds" {{action "fitBounds"}} class="button tiny hollow">Fit map to all {{model.value.id}} districts</button>
   {{/if}}
 </div>
 

--- a/app/templates/components/bookmark-button.hbs
+++ b/app/templates/components/bookmark-button.hbs
@@ -1,4 +1,4 @@
-<button class="save-button bookmark-save-button hide-for-print {{if saved 'saved'}}" onclick={{action 'toggleSaved'}}>
+<button data-test-bookmark="save" data-test-bookmark-button-saved={{if saved 'true' 'false'}} class="save-button bookmark-save-button hide-for-print {{if saved 'saved'}}" onclick={{action 'toggleSaved'}}>
   {{fa-icon "bookmark"}}
   <span class="state">{{#if saved}}SAVED{{/if}}</span>
 </button>

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -134,6 +134,7 @@
     as |container|
   }}
     {{#container.layer-group-toggle
+        data-test-toggle-mandatory-inclusionary-housing
         label=layerGroups.mandatory-inclusionary-housing.legend.label
         tooltip=layerGroups.mandatory-inclusionary-housing.legend.tooltip
         infoLink=layerGroups.mandatory-inclusionary-housing.legend.infolink
@@ -142,6 +143,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-inclusionary-housing
         label=layerGroups.inclusionary-housing.legend.label
         tooltip=layerGroups.inclusionary-housing.legend.tooltip
         infoLink=layerGroups.inclusionary-housing.legend.infolink
@@ -150,6 +152,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-transit-zones
         label=layerGroups.transit-zones.legend.label
         tooltip=layerGroups.transit-zones.legend.tooltip
         infoLink=layerGroups.transit-zones.legend.infolink
@@ -158,6 +161,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-fresh
         label=layerGroups.fresh.legend.label
         tooltip=layerGroups.fresh.legend.tooltip
         infoLink=layerGroups.fresh.legend.infolink
@@ -167,6 +171,7 @@
      {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-sidewalk-cafes
         label=layerGroups.sidewalk-cafes.legend.label
         tooltip=layerGroups.sidewalk-cafes.legend.tooltip
         infoLink=layerGroups.sidewalk-cafes.legend.infolink
@@ -175,6 +180,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-limited-height-districts
         label=layerGroups.limited-height-districts.legend.label
         tooltip=layerGroups.limited-height-districts.legend.tooltip
         icon=layerGroups.limited-height-districts.legend.icon
@@ -182,6 +188,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-low-density-growth-mgmt-areas
         label=layerGroups.low-density-growth-mgmt-areas.legend.label
         tooltip=layerGroups.low-density-growth-mgmt-areas.legend.tooltip
         infoLink=layerGroups.low-density-growth-mgmt-areas.legend.infolink
@@ -190,6 +197,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-coastal-zone-boundary
         label=layerGroups.coastal-zone-boundary.legend.label
         tooltip=layerGroups.coastal-zone-boundary.legend.tooltip
         infoLink=layerGroups.coastal-zone-boundary.legend.infolink
@@ -198,6 +206,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-waterfront-access-plan
         label=layerGroups.waterfront-access-plan.legend.label
         tooltip=layerGroups.waterfront-access-plan.legend.tooltip
         infoLink=layerGroups.waterfront-access-plan.legend.infolink
@@ -206,6 +215,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-historic-districts
         label=layerGroups.historic-districts.legend.label
         tooltip=layerGroups.historic-districts.legend.tooltip
         icon=layerGroups.historic-districts.legend.icon
@@ -213,6 +223,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-landmarks
         label=layerGroups.landmarks.legend.label
         tooltip=layerGroups.landmarks.legend.tooltip
         active=layerGroups.landmarks.visible}}
@@ -220,6 +231,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-floodplain-efirm2007
         label=layerGroups.floodplain-efirm2007.legend.label
         tooltip=layerGroups.floodplain-efirm2007.legend.tooltip
         infoLink=layerGroups.floodplain-efirm2007.legend.infolink
@@ -228,6 +240,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-floodplain-pfirm2015
         label=layerGroups.floodplain-pfirm2015.legend.label
         tooltip=layerGroups.floodplain-pfirm2015.legend.tooltip
         infoLink=layerGroups.floodplain-pfirm2015.legend.infolink
@@ -236,6 +249,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-e-designations
         label=layerGroups.e-designations.legend.label
         tooltip=layerGroups.e-designations.legend.tooltip
         infoLink=layerGroups.e-designations.legend.infolink
@@ -244,6 +258,7 @@
     {{/container.layer-group-toggle}}
 
     {{#container.layer-group-toggle
+        data-test-toggle-appendixj-designated-mdistricts
         label=layerGroups.appendixj-designated-mdistricts.legend.label
         tooltip=layerGroups.appendixj-designated-mdistricts.legend.tooltip
         infoLink=layerGroups.appendixj-designated-mdistricts.legend.infolink

--- a/app/templates/zoning-district.hbs
+++ b/app/templates/zoning-district.hbs
@@ -6,7 +6,7 @@
   <p>{{model.value.description}}</p>
   {{#unless (eq model.value.id 'BPC')}}
     <p><a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/{{primaryzoneURL}}.page" target="_blank">{{fa-icon 'external-link-alt'}} Learn more about {{model.value.id}} districts&hellip;</a></p>
-    <button {{action "fitBounds"}} class="button tiny hollow">Fit map to all {{model.value.id}} districts</button>
+    <button data-test-button="fit-bounds" {{action "fitBounds"}} class="button tiny hollow">Fit map to all {{model.value.id}} districts</button>
   {{else}}
     <p><a href="https://www1.nyc.gov/site/planning/zoning/districts-tools/special-purpose-districts-manhattan.page#battery_park" target="_blank">{{fa-icon 'external-link-alt'}} Learn more about the Special Battery Park City District&hellip;</a></p>
   {{/unless}}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "babel-plugin-transform-object-rest-spread": "^7.0.0-beta.3",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-clean-css": "^2.0.1",
-    "ember-ast-hot-load": "0.0.80",
     "ember-async-await-helper": "0.1.0",
     "ember-auto-import": "^1.2.19",
     "ember-clean-project": "1.0.1",
@@ -47,7 +46,6 @@
     "ember-cli-netlify": "^0.1.0",
     "ember-cli-nouislider": "1.0.0",
     "ember-cli-preprocess-registry": "3.1.2",
-    "ember-cli-qunit": "^4.3.2",
     "ember-cli-sass": "^6.0.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-tree-shaker": "0.2.0",
@@ -75,8 +73,10 @@
     "ember-metrics": "0.13.0",
     "ember-native-dom-helpers": "^0.6.2",
     "ember-parachute": "1.0.2",
+    "ember-percy": "1.5.0",
     "ember-power-select": "^2.0.4",
     "ember-promise-helpers": "^1.0.6",
+    "ember-qunit": "4.4.1",
     "ember-radio-button": "1.2.4",
     "ember-resolver": "^5.0.1",
     "ember-responsive": "3.0.1",
@@ -103,7 +103,7 @@
     "mapbox-gl-draw": "0.16.0",
     "moment": "2.22.2",
     "pretender": "3.0.1",
-    "qunit-dom": "^0.8.4"
+    "sinon": "7.3.2"
   },
   "engines": {
     "node": "8.* || >= 10.*"

--- a/tests/acceptance/bookmarks-test.js
+++ b/tests/acceptance/bookmarks-test.js
@@ -7,7 +7,7 @@ import {
 } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-// import { percySnapshot } from 'ember-percy';
+import { percySnapshot } from 'ember-percy';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
 
@@ -25,14 +25,14 @@ module('Acceptance | bookmarks', function(hooks) {
 
   test('visiting /bookmarks', async function(assert) {
     await visit('/bookmarks');
-    // await percySnapshot('default bookmarks view');
+    await percySnapshot('default bookmarks view');
     assert.equal(currentURL(), '/bookmarks');
   });
 
   test('visiting /bookmarks, see empty message', async function(assert) {
     await visit('/bookmarks');
     await waitUntil(() => find('.content-area'));
-    // await percySnapshot('default empty bookmarks view');
+    await percySnapshot('default empty bookmarks view');
 
     assert.ok(find('.no-bookmarks'));
   });
@@ -40,23 +40,23 @@ module('Acceptance | bookmarks', function(hooks) {
   test('search lot, save, find result in bookmarks, delete it', async function(assert) {
     await visit('/lot/1/47/7501');
     await click('.bookmark-save-button');
-    // await percySnapshot('save button works');
+    await percySnapshot('save button works');
     await visit('/bookmarks');
     await waitUntil(() => find('.content-area'));
-    // await percySnapshot('saved bookmark appears');
+    await percySnapshot('saved bookmark appears');
     await click('.delete-bookmark-button');
-    // await percySnapshot('bookmark deleted');
+    await percySnapshot('bookmark deleted');
 
     assert.ok(find('.no-bookmarks'));
   });
 
   test('bookmark lot, see count increase, un-bookmark', async function(assert) {
     await visit('/lot/1/47/7501');
-    // await percySnapshot('no bookmarks counted');
+    await percySnapshot('no bookmarks counted');
     await click('.bookmark-save-button');
 
     assert.equal(find('.saved-bookmarks-counter .badge').textContent.trim(), '1');
-    // await percySnapshot('counter has incremented');
+    await percySnapshot('counter has incremented');
     await click('.bookmark-save-button');
     assert.equal(find('.saved-bookmarks-counter .badge'), null);
   });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -9,7 +9,7 @@ import {
 } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-// import { percySnapshot } from 'ember-percy';
+import { percySnapshot } from 'ember-percy';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import config from '../../config/environment';
 import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
@@ -42,12 +42,12 @@ module('Acceptance | index', function(hooks) {
 
   test('map-search enter on first search result', async function(assert) {
     await visit('/');
-    // await percySnapshot('view on first load');
+    await percySnapshot('view on first load');
     await fillIn(SEARCH_INPUT_SELECTOR, SEARCH_TERM_LOT);
-    // await percySnapshot('searches');
+    await percySnapshot('searches');
     await waitUntil(() => find('.has-results'), { timeout });
     await click('.result');
-    // await percySnapshot('clicks result');
+    await percySnapshot('clicks result');
 
     assert.equal(
       (currentURL().indexOf('/') > -1),

--- a/tests/acceptance/layer-behavior-tests-test.js
+++ b/tests/acceptance/layer-behavior-tests-test.js
@@ -1,0 +1,586 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  currentURL,
+  find,
+  click,
+  fillIn,
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import layerGroupsFixtures from 'labs-zola/mirage/static-fixtures/layer-groups';
+import stubBasicMap from 'labs-zola/tests/helpers/stub-basic-map';
+import config from 'labs-zola/config/environment';
+import Sinon from 'sinon';
+import resetStorages from 'ember-local-storage/test-support/reset-storage';
+
+const { 'labs-search': { host: labsSearchHost } } = config;
+const DEFAULT_REQUIRED_FEATURE_PROPS = {
+  type: 'Feature',
+  layer: {
+    id: 'pluto-fill',
+  },
+  geometry: {
+    type: 'Polygon',
+    coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+  },
+  properties: {},
+};
+
+const clickMap = async function(map, properties) {
+  map.features = [{
+    ...DEFAULT_REQUIRED_FEATURE_PROPS,
+    properties,
+  }];
+
+  await map.events.mousemove();
+  await map.events.click();
+};
+
+const hoverMap = async function(map, overrides = {}) {
+  map.features = [{
+    ...DEFAULT_REQUIRED_FEATURE_PROPS,
+    ...overrides,
+  }];
+
+  await map.events.mousemove({
+    point: { x: 0, y: 0 },
+  });
+};
+
+const toggleLayerGroupOn = async function(selector) {
+  if (!find(`${selector}.active`)) {
+    await click(`${selector} .layer-group-toggle-label`);
+  }
+};
+
+// this is pretty bad - this assumes that all hoverable layer groups
+// include a layer with an id that has "-fill" affixed.
+const lookupLayerIDsFromFixtures = function(layerGroupId) {
+  const { relationships: { layers } } = layerGroupsFixtures.data
+    .findBy('id', layerGroupId);
+
+  return layers.data.mapBy('id');
+};
+
+const hoverLayerGroup = async function(map, layerGroupId, ...args) {
+  const ids = lookupLayerIDsFromFixtures(layerGroupId);
+  return ids.map(async id => hoverMap(map, { layer: { id } }, ...args));
+};
+
+const assertLayerGroupAdded = async function(testScope, assert, layerGroupId) {
+  // it adds the layers when toggled or if default
+  const ids = lookupLayerIDsFromFixtures(layerGroupId);
+  await toggleLayerGroupOn(`[data-test-toggle-${layerGroupId}]`);
+  ids.forEach(id => assert.ok(testScope.addLayerSpy.calledWithMatch({ id }), `it adds layer: ${id}`));
+};
+
+const assertClickRouteBehavior = async function(testScope, assert, options) {
+  if (find('[data-test-button="close-route"]')) {
+    await click('[data-test-button="close-route"]');
+  }
+
+  const {
+    highlights = true,
+    fitBounds = true,
+    clickObject = {},
+    expectedURL = '',
+  } = options;
+
+  const highlightsAssertMethod = highlights ? 'ok' : 'notOk';
+  const fitBoundsAssertMethod = fitBounds ? 'ok' : 'notOk';
+
+  // when click the layer group
+  await clickMap(testScope.map, clickObject);
+
+  // it routes
+  assert.ok(currentURL().includes(expectedURL), 'it routes');
+
+  // it highlights selected
+  assert[highlightsAssertMethod](testScope.addSourceSpy.calledWith('selected-lot'), `highlights should be ${highlightsAssertMethod}`);
+
+  // it fits bounds on click
+  // the bounding box is assumes to be the computed bounding box of the dummy
+  // data, which is defined in the beforeEach
+  assert[fitBoundsAssertMethod](testScope.fitBoundsSpy.calledWith([0, 0, 1, 1]), `fitting bounds should be ${fitBoundsAssertMethod}`);
+};
+
+const assertCanBookmark = async function(testScope, assert, clickObject) {
+  if (find('[data-test-button="close-route"]')) {
+    await click('[data-test-button="close-route"]');
+  }
+
+  await clickMap(testScope.map, clickObject);
+  await click('[data-test-bookmark="save"]');
+
+  assert.ok(find('[data-test-bookmark-button-saved="true"]'), 'it saves bmark');
+};
+
+const assertFitBoundsOnClick = async function(testScope, assert, clickObject) {
+  if (find('[data-test-button="close-route"]')) {
+    await click('[data-test-button="close-route"]');
+  }
+
+  await clickMap(testScope.map, clickObject);
+  await click('[data-test-button="fit-bounds"]');
+  assert.ok(testScope.fitBoundsSpy.calledWith([0, 0, 1, 1]), 'it fits bounds on click layer');
+};
+
+const assertTooltips = async function(testScope, assert, layerGroupId, assertion = true) {
+  const assertionMethod = assertion ? 'ok' : 'notOk';
+
+  await hoverLayerGroup(testScope.map, layerGroupId);
+  const tooltipSelector = find('[data-test-tooltip="true"]');
+  assert[assertionMethod](tooltipSelector, `tooltips should be ${assertionMethod}`);
+};
+
+const assertSearchShouldFitBounds = async function(testScope, assert, routeIdentifierObject) { // eslint-disable-line
+  if (find('[data-test-button="close-route"]')) {
+    await click('[data-test-button="close-route"]');
+  }
+
+  testScope.server.get(`${labsSearchHost}/**`, function() {
+    return [routeIdentifierObject];
+  });
+
+  await fillIn('.map-search-input', 'arbitrary test string');
+  await click('.result');
+
+  // it fits bounds on click
+  // the bounding box is assumes to be the computed bounding box of the dummy
+  // data, which is defined in the beforeEach
+  assert.ok(testScope.fitBoundsSpy.calledWith([0, 0, 1, 1]), 'it should fit bounds on search');
+};
+
+module('Acceptance | layer behavior tests', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  stubBasicMap(hooks);
+
+  // setup sinon sandbox
+  hooks.before(function() {
+    this.sandbox = Sinon.createSandbox();
+  });
+
+  // inject the layer group fixtures
+  hooks.beforeEach(function() {
+    this.server.post('layer-groups', () => layerGroupsFixtures);
+    this.server.get('https://planninglabs.carto.com/api/v2/sql', (schema, request) => {
+      const { queryParams } = request;
+      const { format } = queryParams;
+
+      if (format === 'geojson') {
+        return {
+          type: 'FeatureCollection',
+          features: [{
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+            },
+            properties: {
+              address: '120 BROADWAY',
+              bbl: 3034430054,
+              id: 3034430054,
+              bldgclass: 'O4',
+              lat: 40.752049929645,
+              lon: -73.9824768690446,
+              block: 841,
+              borough: 'MN',
+              cd: '105',
+              condono: 0,
+              council: '4',
+              firecomp: 'E065',
+              histdist: null,
+              landmark: 'INDIVIDUAL LANDMARK',
+              landuse: '05',
+              lot: 49,
+              lotarea: 32834,
+              lotdepth: 185,
+              lotfront: 197.5,
+              numbldgs: 2,
+              numfloors: 29,
+              ownername: '452 FIFTH OWNERS LLC',
+              ownertype: null,
+              overlay1: null,
+              overlay2: null,
+              policeprct: '14',
+              sanitboro: '1',
+              sanitdistr: '05',
+              sanitsub: '2B',
+              schooldist: '02',
+              spdist1: 'MiD',
+              spdist2: null,
+              spdist3: null,
+              unitsres: 0,
+              unitstotal: 17,
+              yearbuilt: '1902',
+              yearalter1: 2013,
+              yearalter2: 2010,
+              zipcode: 10018,
+              zonedist1: 'C5-3',
+              zonedist2: null,
+              zonedist3: null,
+              zonedist4: null,
+              zonemap: '8d',
+            },
+          }],
+        };
+      }
+
+      return { rows: [] };
+    });
+  });
+
+  // stub the search api
+  hooks.beforeEach(function() {
+    this.server.get(`${labsSearchHost}/**`, function() {
+      return [{ bbl: 1000477501, label: '120 Broadway, Manhattan', type: 'lot' }];
+    });
+  });
+
+  // provide some spies on common mapbox calls
+  hooks.beforeEach(function() {
+    this.addLayerSpy = this.sandbox.spy(this.map, 'addLayer');
+    this.addSourceSpy = this.sandbox.spy(this.map, 'addSource');
+    this.fitBoundsSpy = this.sandbox.spy(this.map, 'fitBounds');
+  });
+
+  // refresh the local storages across tests
+  hooks.beforeEach(function() {
+    if (window.localStorage) {
+      window.localStorage.clear();
+    }
+    if (window.sessionStorage) {
+      window.sessionStorage.clear();
+    }
+    resetStorages();
+  });
+
+  hooks.beforeEach(async function() {
+    await visit('/');
+  });
+
+  // reset sinon
+  hooks.afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  test('Tax Lots', async function(assert) {
+    // it adds the layers when toggled or if default
+    await assertLayerGroupAdded(this, assert, 'tax-lots');
+
+    await assertClickRouteBehavior(this, assert, {
+      highlights: true,
+      fitBounds: true,
+      clickObject: { bbl: 1001870021, cartodb_id: 1001870021 },
+      expectedURL: 'lot/1/187/21',
+    });
+
+    // it bookmarks
+    await assertCanBookmark(this, assert, { bbl: 1001870021, cartodb_id: 1001870021 });
+
+    // it tooltips
+    await assertTooltips(this, assert, 'tax-lots');
+
+
+    // TODO: Make this assertion work.it searches
+    // await assertSearchShouldFitBounds(this, assert, {
+    //   bbl: 1001870021,
+    //   type: 'lot',
+    //   label: '120 Broadway, Manhattan',
+    // });
+  });
+
+  test('Zoning Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'zoning-districts');
+
+    await assertClickRouteBehavior(this, assert, {
+      highlights: true,
+      fitBounds: false,
+      clickObject: { zonedist: '1', cartodb_id: '1' },
+      expectedURL: 'zoning-district/1',
+    });
+
+    // TODO: Make this assertion work.
+    // await assertCanBookmark(this, assert, { zonedist: '1', cartodb_id: '1' });
+
+    await assertFitBoundsOnClick(this, assert, { zonedist: '1', cartodb_id: '1' });
+
+    await assertTooltips(this, assert, 'zoning-districts', true);
+
+    // TODO: Make this assertion work.
+    // await assertSearchShouldFitBounds(this, assert, {
+    //   type: 'zoning-district',
+    //   label: 'C1-5',
+    // });
+  });
+
+  test('Commercial Overlays', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'commercial-overlays');
+
+    await assertClickRouteBehavior(this, assert, {
+      highlights: true,
+      fitBounds: false,
+      clickObject: { overlay: '1', cartodb_id: '1' },
+      expectedURL: 'commercial-overlay/1',
+    });
+
+    // TODO: Make this assertion work.
+    // await assertCanBookmark(this, assert, { overlay: '1', cartodb_id: '1' });
+
+    await assertFitBoundsOnClick(this, assert, { overlay: '1', cartodb_id: '1' });
+
+    await assertTooltips(this, assert, 'commercial-overlays', true);
+
+    // TODO: Make this assertion work.
+    // await assertSearchShouldFitBounds(this, assert, {
+    //   type: 'commercial-overlay',
+    //   label: 'test-overlay',
+    // });
+  });
+
+  test('Zoning Map Amendments', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'zoning-map-amendments');
+
+    await assertClickRouteBehavior(this, assert, {
+      highlights: true,
+      fitBounds: false,
+      clickObject: { ulurpno: '1', cartodb_id: '1' },
+      expectedURL: 'zma/1',
+    });
+
+    await assertCanBookmark(this, assert, { ulurpno: '1', cartodb_id: '1' });
+
+    await assertTooltips(this, assert, 'zoning-map-amendments', true);
+
+    // TODO: Make this assertion work.
+    // await assertSearchShouldFitBounds(this, assert, {
+    //   ulurpno: 'test',
+    //   type: 'zma',
+    //   label: '120 Broadway, Manhattan',
+    // });
+  });
+
+  test('Pending Zoning Map Amendments', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'zoning-map-amendments-pending');
+
+    await assertClickRouteBehavior(this, assert, {
+      highlights: true,
+      fitBounds: false,
+      clickObject: { ulurpno: '1', cartodb_id: '1' },
+      expectedURL: 'zma/1',
+    });
+
+    await assertCanBookmark(this, assert, { ulurpno: '1', cartodb_id: '1' });
+
+    await assertTooltips(this, assert, 'zoning-map-amendments-pending', true);
+
+    // TODO: Make this assertion work.
+    // await assertSearchShouldFitBounds(this, assert, {
+    //   ulurpno: 'test',
+    //   type: 'zma',
+    //   label: '120 Broadway, Manhattan',
+    // });
+  });
+
+  test('Special Purpose Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'special-purpose-districts');
+
+    await assertClickRouteBehavior(this, assert, {
+      highlights: true,
+      fitBounds: false,
+      clickObject: { sdlbl: '1', cartodb_id: '1' },
+      expectedURL: 'special-purpose-district/1',
+    });
+
+    await assertCanBookmark(this, assert, { sdlbl: '1', cartodb_id: '1' });
+
+    await assertTooltips(this, assert, 'special-purpose-districts', false);
+
+    // TODO: Make this assertion work.
+    // await assertSearchShouldFitBounds(this, assert, {
+    //   type: 'special-purpose-district',
+    //   sdname: 'test',
+    //   cartodb_id: 'test',
+    //   label: '120 Broadway, Manhattan',
+    // });
+  });
+
+  test('Special Purpose Subdistricts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'special-purpose-subdistricts');
+
+    await assertClickRouteBehavior(this, assert, {
+      highlights: true,
+      fitBounds: false,
+      clickObject: { splbl: '1', cartodb_id: '1' },
+      expectedURL: 'special-purpose-subdistrict/1',
+    });
+
+    await assertCanBookmark(this, assert, { splbl: '1', cartodb_id: '1' });
+
+    await assertTooltips(this, assert, 'special-purpose-subdistricts', true);
+  });
+
+  test('Second class: Limited Height Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'limited-height-districts');
+
+    await assertTooltips(this, assert, 'limited-height-districts', true);
+  });
+
+  test('Second class: Mandatory Inclusionary Housing Areas', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'mandatory-inclusionary-housing');
+
+    await assertTooltips(this, assert, 'mandatory-inclusionary-housing', true);
+  });
+
+  test('Second class: Inclusionary Housing Designated Areas', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'inclusionary-housing');
+
+    await assertTooltips(this, assert, 'inclusionary-housing', true);
+  });
+
+  test('Second class: Transit Zones', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'transit-zones');
+
+    await assertTooltips(this, assert, 'transit-zones', true);
+  });
+
+  test('Second class: FRESH Zones', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'fresh');
+
+    await assertTooltips(this, assert, 'fresh', true);
+  });
+
+  test('Second class: Sidewalk Cafes', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'sidewalk-cafes');
+
+    await assertTooltips(this, assert, 'sidewalk-cafes', false);
+  });
+
+  test('Second class: Lower Density Growth Management Areas', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'low-density-growth-mgmt-areas');
+
+    await assertTooltips(this, assert, 'low-density-growth-mgmt-areas', true);
+  });
+
+  test('Second class: Coastal Zone Boundary', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'coastal-zone-boundary');
+
+    await assertTooltips(this, assert, 'coastal-zone-boundary', true);
+  });
+
+  test('Second class: Waterfront Access Plan', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'waterfront-access-plan');
+
+    await assertTooltips(this, assert, 'waterfront-access-plan', true);
+  });
+
+  test('Second class: Historic Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'historic-districts');
+
+    await assertTooltips(this, assert, 'historic-districts', true);
+  });
+
+  test('Second class: Landmarks', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'landmarks');
+
+    await assertTooltips(this, assert, 'landmarks', true);
+  });
+
+  test('Second class: Effective Flood Insurance Rate Maps 2007', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'floodplain-efirm2007');
+
+    await assertTooltips(this, assert, 'floodplain-efirm2007', true);
+  });
+
+  test('Second class: Preliminary Flood Insurance Rate Maps 2015', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'floodplain-pfirm2015');
+
+    await assertTooltips(this, assert, 'floodplain-pfirm2015', true);
+  });
+
+  test('Second class: Environmental Designations', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'e-designations');
+
+    await assertTooltips(this, assert, 'e-designations', true);
+  });
+
+  test('Second class: Appendix J Designated M Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'appendixj-designated-mdistricts');
+
+    await assertTooltips(this, assert, 'appendixj-designated-mdistricts', true);
+  });
+
+  test('Second class: Business Improvement Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'business-improvement-districts');
+
+    await assertTooltips(this, assert, 'business-improvement-districts', true);
+  });
+
+  test('Second class: Industrial Business Zones', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'industrial-business-zones');
+
+    await assertTooltips(this, assert, 'industrial-business-zones', true);
+  });
+
+  test('Second class: Boroughs', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'boroughs');
+
+    await assertTooltips(this, assert, 'boroughs', false);
+  });
+
+  test('Second class: Community Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'community-districts');
+
+    await assertTooltips(this, assert, 'community-districts', false);
+  });
+
+  test('Second class: NYC Council Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'nyc-council-districts');
+
+    await assertTooltips(this, assert, 'nyc-council-districts', false);
+  });
+
+  test('Second class: NY State Senate Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'ny-senate-districts');
+
+    await assertTooltips(this, assert, 'ny-senate-districts', false);
+  });
+
+  test('Second class: NY State Assembly Districts', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'assembly-districts');
+
+    await assertTooltips(this, assert, 'assembly-districts', false);
+  });
+
+  test('Second class: Neighborhood Tabulation Areas', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'neighborhood-tabulation-areas');
+
+    await assertTooltips(this, assert, 'neighborhood-tabulation-areas', false);
+  });
+
+  test('Second class: Subways', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'subway');
+
+    await assertTooltips(this, assert, 'subway', false);
+  });
+
+  test('Second class: Building Footprints', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'building-footprints');
+
+    await assertTooltips(this, assert, 'building-footprints', false);
+  });
+
+  test('Second class: 3D Buildings', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'three-d-buildings');
+
+    await assertTooltips(this, assert, 'three-d-buildings', false);
+  });
+
+  test('Second class: Aerial Imagery', async function(assert) {
+    await assertLayerGroupAdded(this, assert, 'aerials');
+
+    await assertTooltips(this, assert, 'aerials', false);
+  });
+});

--- a/tests/acceptance/navigating-to-qpd-url-breaks-test.js
+++ b/tests/acceptance/navigating-to-qpd-url-breaks-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { visit, click, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-// import { percySnapshot } from 'ember-percy';
+import { percySnapshot } from 'ember-percy';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import refresh from '../helpers/refresh';
 import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
@@ -33,12 +33,12 @@ module('Acceptance | navigating to qpd url breaks', function(hooks) {
 
     await click('[data-test-about-close-button]');
 
-    // await percySnapshot('qp test: visit index, change some things');
+    await percySnapshot('qp test: visit index, change some things');
 
     // the refresh here resets the context, requiring re-mocking
     await refresh();
 
-    // await percySnapshot('after a refresh, previous QPs still applies');
+    await percySnapshot('after a refresh, previous QPs still applies');
 
     const boroughs = await find('[data-test-toggle-boroughs] input');
     const cds = await find('[data-test-grouped-parent="Commercial Districts"]');

--- a/tests/acceptance/query-params-persist-test.js
+++ b/tests/acceptance/query-params-persist-test.js
@@ -6,7 +6,7 @@ import {
   find,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-// import { percySnapshot } from 'ember-percy';
+import { percySnapshot } from 'ember-percy';
 import { defaultLayerGroupState } from 'labs-zola/routes/application';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
@@ -30,7 +30,7 @@ module('Acceptance | query params persist', function(hooks) {
 
   test('Navigating without layer group QPs shows default layers on, redirects', async function(assert) {
     await visit('/');
-    // await percySnapshot(assert);
+    await percySnapshot(assert);
 
     // loop over and check each one, seeing if it's toggled in DOM
     defaultVisible.forEach((id) => {
@@ -49,7 +49,7 @@ module('Acceptance | query params persist', function(hooks) {
     const testParams = defaultNonVisible.slice(0, defaultVisible.length - 1);
 
     await visit(`/about?layer-groups=[${testParams.map(l => `"${l}"`)}]`);
-    // await percySnapshot(assert);
+    await percySnapshot(assert);
 
     // loop over and check each one, seeing if it's toggled in DOM
     testParams.forEach((id) => {
@@ -75,7 +75,7 @@ module('Acceptance | query params persist', function(hooks) {
     const testParams = defaultNonVisible.slice(0, defaultVisible.length + 1);
 
     await visit(`/about?layer-groups=[${testParams.map(l => `"${l}"`)}]`);
-    // await percySnapshot(assert);
+    await percySnapshot(assert);
 
     // loop over and check each one, seeing if it's toggled in DOM
     testParams.forEach((id) => {
@@ -101,7 +101,7 @@ module('Acceptance | query params persist', function(hooks) {
     const testParams = defaultNonVisible.slice(0, defaultVisible.length - 2);
 
     await visit(`/about?layer-groups=[${testParams.map(l => `"${l}"`)}]`);
-    // await percySnapshot(assert);
+    await percySnapshot(assert);
 
     // loop over and check each one, seeing if it's toggled in DOM
     testParams.forEach((id) => {

--- a/tests/acceptance/user-can-configure-print-view-test.js
+++ b/tests/acceptance/user-can-configure-print-view-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { visit, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-// import { percySnapshot } from 'ember-percy';
+import { percySnapshot } from 'ember-percy';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
 
@@ -16,15 +16,15 @@ module('Acceptance | user can configure print view', function(hooks) {
   test('User can click print and configure', async function(assert) {
     await visit('/');
     await click('[data-test-map-print-button]');
-    // await percySnapshot('default print view');
+    await percySnapshot('default print view');
 
     await click('[data-test-print-control="landscape"]');
     await click('[data-test-print-control="legal"]');
     await click('[data-test-print-control="legend"]');
-    // await percySnapshot('arbitrary configured print view');
+    await percySnapshot('arbitrary configured print view');
 
     await click('[data-test-exit-print]');
-    // await percySnapshot('exited print view');
+    await percySnapshot('exited print view');
 
     assert.ok(true);
   });

--- a/tests/acceptance/visit-lot-test.js
+++ b/tests/acceptance/visit-lot-test.js
@@ -1,7 +1,7 @@
 import { currentURL, find, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-// import { percySnapshot } from 'ember-percy';
+import { percySnapshot } from 'ember-percy';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
 
@@ -16,14 +16,14 @@ module('Acceptance | visit lot', function(hooks) {
 
   test('visiting a lot', async function(assert) {
     await visit('/lot/1/1632/1');
-    // await percySnapshot('lot view');
+    await percySnapshot('lot view');
 
     assert.notEqual(find('.content-area').textContent.length, 0);
   });
 
   test('visiting a bbl', async function(assert) {
     await visit('/bbl/1001870021');
-    // await percySnapshot('lot view');
+    await percySnapshot('lot view');
     assert.equal(currentURL(), '/lot/1/187/21?layer-groups=%5B%22building-footprints%22%2C%22commercial-overlays%22%2C%22street-centerlines%22%2C%22subway%22%2C%22tax-lots%22%2C%22zoning-districts%22%5D');
     assert.notEqual(find('.content-area').textContent.length, 0);
   });

--- a/tests/acceptance/visual-diff-routes-test.js
+++ b/tests/acceptance/visual-diff-routes-test.js
@@ -1,0 +1,160 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
+
+const SQUARE_POLYGON = {
+  type: 'Polygon',
+  coordinates: [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+};
+
+const generateMockCartoGeoJSONResponse = (testScope, properties) => {
+  testScope.server.get('https://planninglabs.carto.com/api/v2/sql', (schema, request) => {
+    const { queryParams } = request;
+    const { format } = queryParams;
+
+    if (format === 'geojson') {
+      return {
+        type: 'FeatureCollection',
+        features: [{
+          type: 'Feature',
+          geometry: SQUARE_POLYGON,
+          properties,
+        }],
+      };
+    }
+
+    return { rows: [] };
+  });
+};
+
+module('Acceptance | visual diff routes', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function() {
+    this.server.post('layer-groups', () => layerGroupsFixtures);
+  });
+
+  test('visiting lot/1/187/21', async function(assert) {
+    generateMockCartoGeoJSONResponse(this, {
+      id: '118721',
+      address: '32 WEST 25 STREET',
+      bbl: 1008260061,
+      bldgarea: 5000,
+      bldgclass: 'K1',
+      lat: 40.7434315461862,
+      lon: -73.9906654966893,
+      block: 826,
+      borough: 'MN',
+      cd: '105',
+      condono: 0,
+      council: '3',
+      firecomp: 'E001',
+      histdist: null,
+      landmark: null,
+      landuse: '05',
+      lot: 61,
+      lotarea: 4938,
+      lotdepth: 98.75,
+      lotfront: 50,
+      numbldgs: 1,
+      numfloors: 1,
+      ownername: 'HMH SPECIAL LLC',
+      ownertype: null,
+      overlay1: null,
+      overlay2: null,
+      policeprct: '13',
+      sanitboro: '1',
+      sanitdistr: '05',
+      sanitsub: '1B',
+      schooldist: '02',
+      spdist1: null,
+      spdist2: null,
+      spdist3: null,
+      unitsres: 0,
+      unitstotal: 1,
+      yearbuilt: '1935',
+      yearalter1: 0,
+      yearalter2: 0,
+      zipcode: 10010,
+      zonedist1: 'M1-6',
+      zonedist2: null,
+      zonedist3: null,
+      zonedist4: null,
+      zonemap: '8d',
+    });
+
+    await visit('lot/1/187/21');
+    await percySnapshot('lot/1/187/21');
+
+    assert.ok(true);
+  });
+
+  test('visiting zoning-district/R3-2', async function(assert) {
+    generateMockCartoGeoJSONResponse(this, { id: 'R3-2' });
+
+    await visit('zoning-district/R3-2');
+    await percySnapshot('zoning-district/R3-2');
+
+    assert.ok(true);
+  });
+
+  test('visiting commercial-overlay/C2-5', async function(assert) {
+    generateMockCartoGeoJSONResponse(this, {
+      id: 'C2-5',
+      overlay: 'C2-5',
+      address: null,
+    });
+
+    await visit('commercial-overlay/C2-5');
+    await percySnapshot('commercial-overlay/C2-5');
+
+    assert.ok(true);
+  });
+
+  test('visiting zma/090334zmk', async function(assert) {
+    generateMockCartoGeoJSONResponse(this, {
+      id: '090334zmk',
+      ulurpno: null,
+      project_na: 'GREENPOINT-WILLIAMSBURG',
+      effective: '2005-05-11T00:00:00Z',
+      status: 'Adopted',
+      lucats: '050111a',
+      address: null,
+    });
+
+    await visit('zma/090334zmk');
+    await percySnapshot('zma/090334zmk');
+
+    assert.ok(true);
+  });
+
+  test('visiting special-purpose-district/1', async function(assert) {
+    generateMockCartoGeoJSONResponse(this, {
+      id: 1,
+      sdlbl: 'MiD',
+      sdname: 'Special Midtown District',
+    });
+
+    await visit('special-purpose-district/1');
+    await percySnapshot('special-purpose-district/1');
+
+    assert.ok(true);
+  });
+
+  test('visiting special-purpose-subdistrict/96', async function(assert) {
+    generateMockCartoGeoJSONResponse(this, {
+      id: 96,
+      splbl: 'LIC',
+      spname: 'Special Long Island City Mixed Use District',
+    });
+
+    await visit('special-purpose-subdistrict/96');
+    await percySnapshot('special-purpose-subdistrict/96');
+
+    assert.ok(true);
+  });
+});

--- a/tests/helpers/stub-basic-map.js
+++ b/tests/helpers/stub-basic-map.js
@@ -32,7 +32,17 @@ export const MAPBOX_GL_DEFAULTS = {
 
   // registers an event, merges features into signature
   // and returns a promise to makes sure app is settled
-  on(event, callback) {
+  on(event, ...args) {
+    // map.on allows for the second arg to be an
+    // id, for example, of a layer, scoping the
+    // event callback to that layer
+    const [secondArg, thirdArg] = args;
+    let callback = secondArg;
+
+    if (secondArg && thirdArg) {
+      callback = thirdArg;
+    }
+
     this.events[event] = async (hash = {}) => {
       callback({
         features: this.features,
@@ -61,6 +71,7 @@ export const MAPBOX_GL_DEFAULTS = {
   resize() {},
   off() {},
   fitBounds() {},
+  flyTo() {},
   querySourceFeatures() {
     return this.features;
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,14 +768,15 @@
     ember-cli-babel "^6.16.0"
     ember-compatibility-helpers "^1.1.1"
 
-"@ember/test-helpers@^0.7.26":
-  version "0.7.27"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.27.tgz#c622cabd0cbb95b34efc1e1b6274ab5a14edc138"
+"@ember/test-helpers@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-1.5.0.tgz#a480181c412778294e317c256d04ca52e63c813a"
   dependencies:
-    broccoli-funnel "^2.0.1"
-    ember-assign-polyfill "~2.4.0"
-    ember-cli-babel "^6.12.0"
-    ember-cli-htmlbars-inline-precompile "^1.0.0"
+    broccoli-debug "^0.6.5"
+    broccoli-funnel "^2.0.2"
+    ember-assign-polyfill "^2.6.0"
+    ember-cli-babel "^7.4.3"
+    ember-cli-htmlbars-inline-precompile "^2.1.0"
 
 "@fortawesome/ember-fontawesome@0.1.13", "@fortawesome/ember-fontawesome@^0.1.5", "@fortawesome/ember-fontawesome@^0.1.9":
   version "0.1.13"
@@ -976,6 +977,31 @@
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.1.0", "@sinonjs/formatio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.1.tgz#e88c53fbd9d91ad9f0f2b0140c16c7c107fe0d07"
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    array-from "^2.1.1"
+    lodash "^4.17.11"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
 
 "@turf/area@^6.0.1":
   version "6.0.1"
@@ -1633,6 +1659,10 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+
 array-includes@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
@@ -1955,7 +1985,7 @@ babel-plugin-debug-macros@^0.3.0:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-ember-modules-api-polyfill@>=2.0.1, babel-plugin-ember-modules-api-polyfill@^2.3.0, babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.8.0:
+babel-plugin-ember-modules-api-polyfill@^2.3.0, babel-plugin-ember-modules-api-polyfill@^2.6.0, babel-plugin-ember-modules-api-polyfill@^2.8.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.9.0.tgz#8503e7b4192aeb336b00265e6235258ff6b754aa"
   dependencies:
@@ -2354,7 +2384,7 @@ base64-js@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.2.tgz#024f0f72afa25b75f9c0ee73cd4f55ec1bed9784"
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
 
@@ -2433,6 +2463,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird-retry@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/bluebird-retry/-/bluebird-retry-0.11.0.tgz#1289ab22cbbc3a02587baad35595351dd0c1c047"
+
 bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@~3.5.0:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
@@ -2441,7 +2475,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
-body-parser@1.19.0, body-parser@^1.18.3:
+body-parser@1.19.0, body-parser@^1.15.0, body-parser@^1.18.3:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   dependencies:
@@ -3016,7 +3050,7 @@ broccoli-stew@^1.5.0:
     symlink-or-copy "^1.2.0"
     walk-sync "^0.3.0"
 
-broccoli-stew@^2.0.0, broccoli-stew@^2.0.1, broccoli-stew@^2.1.0:
+broccoli-stew@^2.0.0, broccoli-stew@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-2.1.0.tgz#ba73add17fda3b9b01d8cfb343a8b613b7136a0a"
   dependencies:
@@ -4214,6 +4248,10 @@ dezalgo@^1.0.0, dezalgo@~1.0.3:
     asap "^2.0.0"
     wrappy "1"
 
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 diff@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
@@ -4347,11 +4385,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-ember-assign-polyfill@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.4.0.tgz#acb00466f7d674b3e6b030acfe255b3b1f6472e1"
+ember-assign-polyfill@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.6.0.tgz#07847e3357ee35b33f886a0b5fbec6873f6860eb"
   dependencies:
-    ember-cli-babel "^6.6.0"
+    ember-cli-babel "^6.16.0"
     ember-cli-version-checker "^2.0.0"
 
 ember-ast-helpers@0.3.5:
@@ -4360,15 +4398,6 @@ ember-ast-helpers@0.3.5:
   dependencies:
     "@glimmer/compiler" "^0.27.0"
     "@glimmer/syntax" "^0.27.0"
-
-ember-ast-hot-load@0.0.80:
-  version "0.0.80"
-  resolved "https://registry.yarnpkg.com/ember-ast-hot-load/-/ember-ast-hot-load-0.0.80.tgz#45028f4c627c72870435c85bac0534a0fe039007"
-  dependencies:
-    babel-plugin-ember-modules-api-polyfill ">=2.0.1"
-    broccoli-stew "^2.0.1"
-    ember-cli-babel ">=6.6.0"
-    ember-cli-htmlbars "*"
 
 ember-async-await-helper@0.1.0:
   version "0.1.0"
@@ -4481,7 +4510,25 @@ ember-cli-babel@6.14.1:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@>=6.6.0, ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.1.4, ember-cli-babel@^7.2.0, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.3, ember-cli-babel@^7.1.4, ember-cli-babel@^7.2.0, ember-cli-babel@^7.4.3, ember-cli-babel@^7.5.0, ember-cli-babel@^7.7.0, ember-cli-babel@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
   dependencies:
@@ -4505,24 +4552,6 @@ ember-cli-babel@>=6.6.0, ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-c
     ember-cli-babel-plugin-helpers "^1.1.0"
     ember-cli-version-checker "^2.1.2"
     ensure-posix-path "^1.0.2"
-    semver "^5.5.0"
-
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.17.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0, ember-cli-babel@^6.9.2:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
-  dependencies:
-    amd-name-resolver "1.2.0"
-    babel-plugin-debug-macros "^0.2.0-beta.6"
-    babel-plugin-ember-modules-api-polyfill "^2.6.0"
-    babel-plugin-transform-es2015-modules-amd "^6.24.0"
-    babel-polyfill "^6.26.0"
-    babel-preset-env "^1.7.0"
-    broccoli-babel-transpiler "^6.5.0"
-    broccoli-debug "^0.6.4"
-    broccoli-funnel "^2.0.0"
-    broccoli-source "^1.1.0"
-    clone "^2.0.0"
-    ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
 ember-cli-broccoli-sane-watcher@^3.0.0:
@@ -4657,15 +4686,6 @@ ember-cli-htmlbars-inline-precompile@^2.1.0:
     heimdalljs-logger "^0.1.9"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@*, ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-3.0.1.tgz#01e21f0fd05e0a6489154f26614b1041769e3e58"
-  dependencies:
-    broccoli-persistent-filter "^1.4.3"
-    hash-for-dep "^1.2.3"
-    json-stable-stringify "^1.0.0"
-    strip-bom "^3.0.0"
-
 ember-cli-htmlbars@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.5.tgz#65be9678b274b5e7861d7f75c188780af7ef9d13"
@@ -4679,6 +4699,15 @@ ember-cli-htmlbars@^1.1.1:
 ember-cli-htmlbars@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.5.tgz#b5a105429a6bce4f7c9c97b667e3b8926e31397f"
+  dependencies:
+    broccoli-persistent-filter "^1.4.3"
+    hash-for-dep "^1.2.3"
+    json-stable-stringify "^1.0.0"
+    strip-bom "^3.0.0"
+
+ember-cli-htmlbars@^3.0.0, ember-cli-htmlbars@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-3.0.1.tgz#01e21f0fd05e0a6489154f26614b1041769e3e58"
   dependencies:
     broccoli-persistent-filter "^1.4.3"
     hash-for-dep "^1.2.3"
@@ -4777,13 +4806,6 @@ ember-cli-preprocess-registry@^3.3.0:
     broccoli-funnel "^2.0.1"
     debug "^3.0.1"
     process-relative-require "^1.0.0"
-
-ember-cli-qunit@^4.3.2:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-qunit/-/ember-cli-qunit-4.4.0.tgz#0edd7d651001d0d7ea200b9236a4733a5b7420f1"
-  dependencies:
-    ember-cli-babel "^6.11.0"
-    ember-qunit "^3.5.0"
 
 ember-cli-sass@^6.0.0, ember-cli-sass@^6.2.0:
   version "6.2.0"
@@ -5275,6 +5297,16 @@ ember-parachute@1.0.2:
   dependencies:
     ember-cli-babel "^7.1.2"
 
+ember-percy@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/ember-percy/-/ember-percy-1.5.0.tgz#c70d66f7cdcc6078d2b7e18de04e545ac4da9818"
+  dependencies:
+    body-parser "^1.15.0"
+    ember-cli-babel "^6.10.0"
+    es6-promise-pool "^2.4.1"
+    percy-client "^3.0.0"
+    walk "^2.3.9"
+
 ember-power-select@^2.0.4:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-2.3.2.tgz#8bd20989c52ec53e5f526bd5d3267aac6f0a76f4"
@@ -5292,17 +5324,17 @@ ember-promise-helpers@1.0.6, ember-promise-helpers@^1.0.6:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-ember-qunit@^3.5.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.5.3.tgz#bfd0bff8298c78c77e870cca43fe0826e78a0d09"
+ember-qunit@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-4.4.1.tgz#3654cadf9fa7e2287fe7b61fc7f19c3eb06222b5"
   dependencies:
-    "@ember/test-helpers" "^0.7.26"
-    broccoli-funnel "^2.0.1"
-    broccoli-merge-trees "^2.0.0"
+    "@ember/test-helpers" "^1.5.0"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^3.0.2"
     common-tags "^1.4.0"
-    ember-cli-babel "^6.8.2"
+    ember-cli-babel "^7.5.0"
     ember-cli-test-loader "^2.2.0"
-    qunit "~2.6.0"
+    qunit "^2.9.2"
 
 ember-radio-button@1.2.4:
   version "1.2.4"
@@ -5579,6 +5611,10 @@ es6-map@^0.1.4:
     es6-set "~0.1.5"
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
+
+es6-promise-pool@^2.4.1, es6-promise-pool@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz#147c612b36b47f105027f9d2bf54a598a99d9ccb"
 
 es6-promise@^4.0.3:
   version "4.2.6"
@@ -5966,10 +6002,6 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-exists-stat@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/exists-stat/-/exists-stat-1.0.0.tgz#0660e3525a2e89d9e446129440c272edfa24b529"
-
 exists-sync@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.0.4.tgz#9744c2c428cc03b01060db454d4b12f0ef3c8879"
@@ -6264,7 +6296,7 @@ find-yarn-workspace-root@^1.1.0, find-yarn-workspace-root@^1.2.1:
     fs-extra "^4.0.3"
     micromatch "^3.1.4"
 
-findup-sync@2.0.0, findup-sync@^2.0.0:
+findup-sync@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
   dependencies:
@@ -6331,6 +6363,10 @@ for-in@^1.0.2:
 foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
+foreachasync@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/foreachasync/-/foreachasync-3.0.0.tgz#5502987dc8714be3392097f32e0071c9dee07cf6"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -7846,6 +7882,14 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+jssha@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/jssha/-/jssha-2.3.1.tgz#147b2125369035ca4b2f7d210dc539f009b3de9a"
+
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+
 kdbush@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-2.0.1.tgz#90c6128e3001ac68c550d7c9e2f222c0269666f1"
@@ -8437,6 +8481,10 @@ log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
+lolex@^4.0.1, lolex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.1.0.tgz#ecdd7b86539391d8237947a3419aa8ac975f0fe1"
+
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -8825,7 +8873,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -9043,6 +9091,16 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
+nise@^1.4.10:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.0.tgz#d03ea0e6c1b75c638015aa3585eddc132949a50d"
+  dependencies:
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^4.1.0"
+    path-to-regexp "^1.7.0"
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -9196,6 +9254,10 @@ node-sass@^4.7.2:
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
+
+node-watch@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/node-watch/-/node-watch-0.6.0.tgz#ab0703b60cd270783698e57a428faa0010ed8fd0"
 
 "nomnom@>= 1.5.x":
   version "1.8.1"
@@ -9859,7 +9921,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
-path-parse@^1.0.5, path-parse@^1.0.6:
+path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
@@ -9880,6 +9942,12 @@ path-root@^0.1.1:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -9917,6 +9985,20 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+percy-client@^3.0.0:
+  version "3.0.12"
+  resolved "https://registry.yarnpkg.com/percy-client/-/percy-client-3.0.12.tgz#325e7fded4860e61b8f219aa1a3653e72cbb1280"
+  dependencies:
+    base64-js "^1.2.3"
+    bluebird "^3.5.1"
+    bluebird-retry "^0.11.0"
+    es6-promise-pool "^2.5.0"
+    jssha "^2.1.0"
+    regenerator-runtime "^0.13.1"
+    request "^2.87.0"
+    request-promise "^4.2.2"
+    walk "^2.3.14"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -10123,7 +10205,7 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-psl@^1.1.24:
+psl@^1.1.24, psl@^1.1.28:
   version "1.1.32"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.32.tgz#3f132717cf2f9c169724b2b6caf373cf694198db"
 
@@ -10175,7 +10257,7 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
-punycode@^2.1.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
@@ -10223,24 +10305,15 @@ quickselect@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
 
-qunit-dom@^0.8.4:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-0.8.5.tgz#34b7cffb338e631c39955b21bdbe4d774090124e"
-  dependencies:
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.1"
-
-qunit@~2.6.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.6.2.tgz#551210c5cf857258a4fe39a7fe15d9e14dfef22c"
+qunit@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.9.2.tgz#97919440c9c0ae838bcd3c33a2ee42f35c5ef4a0"
   dependencies:
     commander "2.12.2"
-    exists-stat "1.0.0"
-    findup-sync "2.0.0"
     js-reporters "1.2.1"
-    resolve "1.5.0"
-    sane "^2.5.2"
-    walk-sync "0.3.2"
+    minimatch "3.0.4"
+    node-watch "0.6.0"
+    resolve "1.9.0"
 
 quote-stream@^1.0.1, quote-stream@~1.0.2:
   version "1.0.2"
@@ -10503,7 +10576,7 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
-regenerator-runtime@^0.13.2:
+regenerator-runtime@^0.13.1, regenerator-runtime@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
 
@@ -10617,6 +10690,21 @@ repeating@^2.0.0:
 replace-ext@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
+
+request-promise-core@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+  dependencies:
+    lodash "^4.17.11"
+
+request-promise@^4.2.2:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.4.tgz#1c5ed0d71441e38ad58c7ce4ea4ea5b06d54b310"
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
 
 "request@>=2.9.0 <2.82.0", request@~2.81.0:
   version "2.81.0"
@@ -10744,11 +10832,11 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+resolve@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
   dependencies:
-    path-parse "^1.0.5"
+    path-parse "^1.0.6"
 
 resolve@^1.1.5, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
   version "1.11.1"
@@ -10945,21 +11033,6 @@ safe-regex@^1.1.0:
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-
-sane@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-2.5.2.tgz#b4dc1861c21b427e929507a3e751e2a2cb8ab3fa"
-  dependencies:
-    anymatch "^2.0.0"
-    capture-exit "^1.2.0"
-    exec-sh "^0.2.0"
-    fb-watchman "^2.0.0"
-    micromatch "^3.1.4"
-    minimist "^1.1.1"
-    walker "~1.0.5"
-    watch "~0.18.0"
-  optionalDependencies:
-    fsevents "^1.2.3"
 
 sane@^3.0.0:
   version "3.1.0"
@@ -11162,6 +11235,18 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0, silent-error@^1.1
 simple-html-tokenizer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz#9b8b5559d80e331a544dd13dd59382e5d0d94411"
+
+sinon@7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.3.2.tgz#82dba3a6d85f6d2181e1eca2c10d8657c2161f28"
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.1"
+    diff "^3.5.0"
+    lolex "^4.0.1"
+    nise "^1.4.10"
+    supports-color "^5.5.0"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -11518,6 +11603,10 @@ stdout-stream@^1.4.0:
   dependencies:
     readable-stream "^2.0.1"
 
+stealthy-require@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -11676,7 +11765,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^5.0.0, supports-color@^5.3.0:
+supports-color@^5.0.0, supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:
@@ -11996,6 +12085,13 @@ touch@^3.1.0:
   dependencies:
     nopt "~1.0.10"
 
+tough-cookie@^2.3.3:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
+
 tough-cookie@~2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
@@ -12064,6 +12160,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
@@ -12413,13 +12513,6 @@ vt-pbf@^3.0.1, vt-pbf@^3.1.1:
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.0.5"
 
-walk-sync@0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
-  dependencies:
-    ensure-posix-path "^1.0.0"
-    matcher-collection "^1.0.0"
-
 walk-sync@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.1.3.tgz#8a07261a00bda6cfb1be25e9f100fad57546f583"
@@ -12445,6 +12538,12 @@ walk-sync@^1.0.0, walk-sync@^1.1.3:
     "@types/minimatch" "^3.0.3"
     ensure-posix-path "^1.1.0"
     matcher-collection "^1.1.1"
+
+walk@^2.3.14, walk@^2.3.9:
+  version "2.3.14"
+  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.14.tgz#60ec8631cfd23276ae1e7363ce11d626452e1ef3"
+  dependencies:
+    foreachasync "^3.0.0"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
This PR adds a much-needed implementation of tests based on the "layer behavior grid". This test suite will let us move move forward with code improvements.

Note that there are 5 of these tests that are set up as "todo" tests, meaning they fail (in 1 of 8 assertions), but may still be merged as they are behaviors that do not match up with what the behavior grid asks for.

Also, Percy snapshots don't work for the map just yet, and I don't have any plans to do it. Getting Percy to work with the map requires doing additional complex test-environment-specific work. I'd like to find a more general solution.

