### PR TITLE
805 preserve hash

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -42,16 +42,6 @@ export default class MainMap extends Component {
   @service
   router;
 
-  lat = 40.7125;
-
-  @computed()
-  get lng() {
-    const boundsOptions = this.get('mainMap.isSelectedBoundsOptions');
-    return boundsOptions.offset[0] === 0 ? -73.9022 : -73.733;
-  }
-
-  zoom = 9.72;
-
   menuTo = 'layers-menu';
 
   loading = true;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -14,7 +14,12 @@ export default Route.extend({
     if (targetName === 'index') {
       const { hash } = window.location;
 
-      this.transitionTo(`/about${transition.intent.url}${hash}`);
+      // preserve hash token so it's applied across transitions
+      if (hash) {
+        this.mainMap.set('knownHashIntent', hash);
+      }
+
+      this.transitionTo(`/about${transition.intent.url}`);
     }
 
     if (targetName === 'lot') {

--- a/app/services/main-map.js
+++ b/app/services/main-map.js
@@ -2,6 +2,11 @@ import Service from '@ember/service';
 import { computed } from '@ember/object';
 import { timeout, task } from 'ember-concurrency';
 
+const DEFAULT_ZOOM = 9.72;
+const DEFAULT_LNG = 40.7125;
+const DEFAULT_LAT = -73.733;
+const DEFAULT_LAT_OFFSET = -0.1692;
+
 export default class MainMapService extends Service {
   mapInstance = null;
 
@@ -17,6 +22,40 @@ export default class MainMapService extends Service {
   shouldFitBounds = false;
 
   routeIntentIsNested = false;
+
+  knownHashIntent = '';
+
+  @computed
+  get parsedHash() {
+    if (this.knownHashIntent) {
+      return this.knownHashIntent.replace('#', '').split('/').reverse();
+    }
+
+    return [9.72, 40.7125, -73.733];
+  }
+
+  @computed
+  get zoom() {
+    if (this.knownHashIntent) {
+      const [,, z] = this.parsedHash;
+      return z;
+    }
+
+    return DEFAULT_ZOOM;
+  }
+
+  @computed
+  get center() {
+    if (this.knownHashIntent) {
+      const [x, y] = this.parsedHash;
+      return [x, y];
+    }
+
+    const boundsOptions = this.isSelectedBoundsOptions;
+    const x = (boundsOptions.offset[0] === 0) ? (DEFAULT_LAT + DEFAULT_LAT_OFFSET) : DEFAULT_LAT;
+
+    return [x, DEFAULT_LNG];
+  }
 
   @computed('selected', 'routeIntentIsNested')
   get isSelectedBoundsOptions() {

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -2,11 +2,11 @@
   @name="main-map"
   @layerGroups={{this.layerGroups}}
   @initOptions={{hash
-    style=layerGroupsMeta.mapboxStyle
+    style=this.layerGroupsMeta.mapboxStyle
     preserveDrawingBuffer=true
-    zoom=zoom
+    zoom=this.mainMap.zoom
     hash=true
-    center=(array lng lat)
+    center=this.mainMap.center
   }}
   @mapLoaded={{action "handleMapLoad"}} as |map|
 >

--- a/tests/acceptance/root-query-params-honored-after-redirect-test.js
+++ b/tests/acceptance/root-query-params-honored-after-redirect-test.js
@@ -3,10 +3,12 @@ import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import layerGroupsFixtures from '../../mirage/static-fixtures/layer-groups';
+import stubBasicMap from '../helpers/stub-basic-map';
 
 module('Acceptance | root query params honored after redirect', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  stubBasicMap(hooks);
 
   hooks.beforeEach(function() {
     this.server.post('layer-groups', () => layerGroupsFixtures);
@@ -17,4 +19,13 @@ module('Acceptance | root query params honored after redirect', function(hooks) 
 
     assert.equal(currentURL(), '/about?layer-groups=%5B%22street-centerlines%22%2C%22tax-lots%22%5D');
   });
+
+  // I cannot test that the hash works in test suite
+  // There's some virtualization going on that's missing location hashes.
+  // This should be asserted someday.
+  // test('visiting site with map hash honored after redirect', async function(assert) {
+  //   await visit('/#15.67/40.753686/-73.984754');
+
+  //   assert.equal(currentURL(), '/about#15.67/40.753686/-73.984754');
+  // });
 });


### PR DESCRIPTION
Closes #805 

Preserves the hash on redirect from application route to about.

Requires changes to service to store hash state.

I could not find a way to correctly pass the hash value in `transitionTo`