### PR TITLE
876 componentize print feature concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In the spirit of free software, everyone is encouraged to help improve this proj
 
 - Clone this repository: `git clone https://github.com/NYCPlanning/labs-zola.git`
 - Navigate to the repo: `cd labs-zola`
-- Install dependencies: `npm install`
+- Install dependencies: `yarn`
 - Run the development server: `ember serve`
 
 ## Architecture

--- a/app/components/main-header.js
+++ b/app/components/main-header.js
@@ -2,7 +2,10 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 
 export default class MainHeaderComponent extends Component {
-  @service
+  @service('print')
+  printSvc
+
+  @service()
   media
 
   bookmarks;

--- a/app/components/print-view-controls.js
+++ b/app/components/print-view-controls.js
@@ -1,18 +1,12 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class PrintViewControls extends Component {
   classNames = ['print-view--controls', 'align-middle'];
 
-  printViewOrientation = 'portrait';
-
-  printViewPaperSize = 'letter';
-
-  printViewShowMap = true;
-
-  printViewShowLegend = true;
-
-  printViewShowContent = true;
+  @service('print')
+  printSvc;
 
   widowResize() {
     return new Promise((resolve) => {
@@ -27,7 +21,7 @@ export default class PrintViewControls extends Component {
 
   @action
   async disablePrintView() {
-    this.set('print', false);
+    this.set('printSvc.enabled', false);
 
     await this.widowResize();
   }

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -46,12 +46,16 @@ export const mapQueryParams = new QueryParams(
         as: 'layer-groups',
       },
 
+      // TODO: After merge of params refactor, update print service based on this param.
       print: { defaultValue: false },
     },
   ),
 );
 
 export default class ApplicationController extends Controller.extend(mapQueryParams.Mixin) {
+  @service('print')
+  printSvc;
+
   @service('layerGroups')
   layerGroupService;
 
@@ -82,37 +86,5 @@ export default class ApplicationController extends Controller.extend(mapQueryPar
     const values = Object.values(state);
 
     return values.isEvery('changed', false);
-  }
-
-  // Print View Settings and computeds
-  // TODO: Refactor this into a separate component
-  printViewOrientation = 'portrait';
-
-  printViewPaperSize = 'letter';
-
-  printViewShowMap = true;
-
-  printViewShowLegend = true;
-
-  printViewShowContent = true;
-
-  @computed('printViewShowMap', 'printViewShowLegend', 'printViewShowContent')
-  get printViewHiddenAreas() {
-    const hiddenAreasClasses = [];
-
-    if (!this.get('printViewShowMap')) hiddenAreasClasses.push('no-map');
-    if (!this.get('printViewShowLegend')) hiddenAreasClasses.push('no-legend');
-    if (!this.get('printViewShowContent')) hiddenAreasClasses.push('no-content');
-
-    return hiddenAreasClasses.join(' ');
-  }
-
-  @computed('printViewHiddenAreas', 'print', 'printViewPaperSize', 'printViewOrientation', 'printViewHiddenAreas')
-  get printViewClasses() {
-    const orientation = this.get('printViewOrientation');
-    const size = this.get('printViewPaperSize');
-    const areas = this.get('printViewHiddenAreas');
-
-    return this.get('print') ? `paper ${size} ${orientation} ${areas}` : '';
   }
 }

--- a/app/services/print.js
+++ b/app/services/print.js
@@ -1,0 +1,37 @@
+import Service from '@ember/service';
+import { computed } from '@ember/object';
+
+export default class PrintService extends Service {
+  enabled = false;
+
+  // Print View Settings
+  printViewOrientation = 'portrait';
+
+  printViewPaperSize = 'letter';
+
+  printViewShowMap = true;
+
+  printViewShowLegend = true;
+
+  printViewShowContent = true;
+
+  @computed('printViewShowMap', 'printViewShowLegend', 'printViewShowContent')
+  get printViewHiddenAreas() {
+    const hiddenAreasClasses = [];
+
+    if (!this.printViewShowMap) hiddenAreasClasses.push('no-map');
+    if (!this.printViewShowLegend) hiddenAreasClasses.push('no-legend');
+    if (!this.printViewShowContent) hiddenAreasClasses.push('no-content');
+
+    return hiddenAreasClasses.join(' ');
+  }
+
+  @computed('printViewHiddenAreas', 'enabled', 'printViewPaperSize', 'printViewOrientation', 'printViewHiddenAreas')
+  get printViewClasses() {
+    const orientation = this.printViewOrientation;
+    const size = this.printViewPaperSize;
+    const areas = this.printViewHiddenAreas;
+
+    return this.enabled ? `paper ${size} ${orientation} ${areas}` : '';
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,21 +1,13 @@
 <MainHeader @bookmarks={{model.bookmarks}} />
-{{! print is chameleon }}
-<div class="{{if print "print-view"}}">
-  {{! what on earth is this for }}
+<div class="{{if this.printSvc.enabled "print-view"}}">
   {{link-to "" "index" class="index-active-detector"}}
-  {{! print is chameleon }}
   {{! data clip below }}
-  {{#if print}}
+  {{#if this.printSvc.enabled}}
     <PrintViewControls
-      @print={{print}}
-      @printViewOrientation={{printViewOrientation}}
-      @printViewPaperSize={{printViewPaperSize}}
-      @printViewShowMap={{printViewShowMap}}
-      @printViewShowLegend={{printViewShowLegend}}
-      @printViewShowContent={{printViewShowContent}}
+      @printSvc={{printSvc}}
     />
   {{/if}}
-  <div class="site-main grid-x {{printViewClasses}}">
+  <div class="site-main grid-x {{this.printSvc.printViewClasses}}">
     <div class="navigation-area cell large-auto">
       {{map-resource-search}}
       <div class="map-grid">
@@ -23,7 +15,7 @@
           @bookmarks={{model.bookmarks}}
           @layerGroups={{model.layerGroups}}
           @layerGroupsMeta={{model.meta}}
-          @print={{print}}
+          @onPrint={{action (mut this.printSvc.enabled) true}}
         />
         <LayerPalette
           @selectedZoning={{this.selectedZoning}}

--- a/app/templates/components/main-header.hbs
+++ b/app/templates/components/main-header.hbs
@@ -1,6 +1,6 @@
 <LabsUi::SiteHeader
   @responsiveNav={{true}}
-  class={{if print "hide-for-print"}} as |banner|
+  class={{if this.printSvc.enabled "hide-for-print"}} as |banner|
 >
   <banner.title>
     {{#link-to
@@ -23,7 +23,7 @@
           </span>
         {{/if}}
         {{#if (or (media "mobile") (media "tablet"))}}
-          NYC's
+          NYC's 
         {{/if}}
         Zoning &amp; Land Use Map
       </small>

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -19,7 +19,7 @@
     <button
       class="mapboxgl-ctrl-icon"
       data-test-map-print-button
-      {{action (mut print) true}}
+      onClick={{action this.onPrint}}
     >
       {{fa-icon "print"}}
     </button>

--- a/app/templates/components/print-view-controls.hbs
+++ b/app/templates/components/print-view-controls.hbs
@@ -11,11 +11,11 @@
     Orientation:
   </h6>
   <button
-    onclick={{action (mut printViewOrientation) "landscape"}}
+    onclick={{action (mut this.printSvc.printViewOrientation) "landscape"}}
     data-test-print-control="landscape"
   >
     <span class="fa-layers">
-      {{#if (eq printViewOrientation "landscape")}}
+      {{#if (eq this.printSvc.printViewOrientation "landscape")}}
         {{fa-icon "circle" class="white"}}
         {{fa-icon "circle" prefix="far" class="light-gray"}}
         {{fa-icon "circle" transform="shrink-6" class="a11y-orange"}}
@@ -27,11 +27,11 @@
     Landscape
   </button>
   <button
-    onclick={{action (mut printViewOrientation) "portrait"}}
+    onclick={{action (mut this.printSvc.printViewOrientation) "portrait"}}
     data-test-print-control="portrait"
   >
     <span class="fa-layers">
-      {{#if (eq printViewOrientation "portrait")}}
+      {{#if (eq this.printSvc.printViewOrientation "portrait")}}
         {{fa-icon "circle" class="white"}}
         {{fa-icon "circle" prefix="far" class="light-gray"}}
         {{fa-icon "circle" transform="shrink-6" class="a11y-orange"}}
@@ -48,11 +48,11 @@
     Size:
   </h6>
   <button
-    onclick={{action (mut printViewPaperSize) "letter"}}
+    onclick={{action (mut this.printSvc.printViewPaperSize) "letter"}}
     data-test-print-control="letter"
   >
     <span class="fa-layers">
-      {{#if (eq printViewPaperSize "letter")}}
+      {{#if (eq this.printSvc.printViewPaperSize "letter")}}
         {{fa-icon "circle" class="white"}}
         {{fa-icon "circle" prefix="far" class="light-gray"}}
         {{fa-icon "circle" transform="shrink-6" class="a11y-orange"}}
@@ -64,11 +64,11 @@
     Letter
   </button>
   <button
-    onclick={{action (mut printViewPaperSize) "legal"}}
+    onclick={{action (mut this.printSvc.printViewPaperSize) "legal"}}
     data-test-print-control="legal"
   >
     <span class="fa-layers">
-      {{#if (eq printViewPaperSize "legal")}}
+      {{#if (eq this.printSvc.printViewPaperSize "legal")}}
         {{fa-icon "circle" class="white"}}
         {{fa-icon "circle" prefix="far" class="light-gray"}}
         {{fa-icon "circle" transform="shrink-6" class="a11y-orange"}}
@@ -80,11 +80,11 @@
     Legal
   </button>
   <button
-    onclick={{action (mut printViewPaperSize) "tabloid"}}
+    onclick={{action (mut this.printSvc.printViewPaperSize) "tabloid"}}
     data-test-print-control="tabloid"
   >
     <span class="fa-layers">
-      {{#if (eq printViewPaperSize "tabloid")}}
+      {{#if (eq this.printSvc.printViewPaperSize "tabloid")}}
         {{fa-icon "circle" class="white"}}
         {{fa-icon "circle" prefix="far" class="light-gray"}}
         {{fa-icon "circle" transform="shrink-6" class="a11y-orange"}}
@@ -102,11 +102,11 @@
   </h6>
   <button
     class="map"
-    onclick={{action (mut printViewShowMap) (not printViewShowMap)}}
+    onclick={{action (mut this.printSvc.printViewShowMap) (not this.printSvc.printViewShowMap)}}
     data-test-print-control="map"
   >
     <span class="fa-layers">
-      {{#if (eq printViewShowMap true)}}
+      {{#if (eq this.printSvc.printViewShowMap true)}}
         {{fa-icon "square" class="white"}}
         {{fa-icon "check-square" class="a11y-orange"}}
       {{else}}
@@ -116,14 +116,14 @@
     </span>
     Map
   </button>
-  {{#if (eq printViewShowMap true)}}
+  {{#if (eq this.printSvc.printViewShowMap true)}}
     <button
       class="legend"
-      onclick={{action (mut printViewShowLegend) (not printViewShowLegend)}}
+      onclick={{action (mut this.printSvc.printViewShowLegend) (not this.printSvc.printViewShowLegend)}}
       data-test-print-control="legend"
     >
       <span class="fa-layers">
-        {{#if (eq printViewShowLegend true)}}
+        {{#if (eq this.printSvc.printViewShowLegend true)}}
           {{fa-icon "square" class="white"}}
           {{fa-icon "check-square" class="a11y-orange"}}
         {{else}}
@@ -143,11 +143,11 @@
   {{/if}}
   <button
     class="content"
-    onclick={{action (mut printViewShowContent) (not printViewShowContent)}}
+    onclick={{action (mut this.printSvc.printViewShowContent) (not this.printSvc.printViewShowContent)}}
     data-test-print-control="content"
   >
     <span class="fa-layers">
-      {{#if (eq printViewShowContent true)}}
+      {{#if (eq this.printSvc.printViewShowContent true)}}
         {{fa-icon "square" class="white"}}
         {{fa-icon "check-square" class="a11y-orange"}}
       {{else}}

--- a/tests/integration/components/main-map-test.js
+++ b/tests/integration/components/main-map-test.js
@@ -27,7 +27,7 @@ module('Integration | Component | main-map', function(hooks) {
   hooks.beforeEach(async function() {
     this.meta = MAPBOX_GL_BLANK_STYLE;
     this.bookmarks = [];
-    this.print = false;
+    this.printSvc = this.owner.lookup('service:print');
   });
 
   test('it renders', async function(assert) {
@@ -42,7 +42,7 @@ module('Integration | Component | main-map', function(hooks) {
         layerGroups=this.layerGroups
         layerGroupsMeta=this.meta
         bookmarks=this.bookmarks
-        print=this.print
+        onPrint=(action (mut this.printSvc.enabled) true)
       }}
     `);
 
@@ -86,7 +86,7 @@ module('Integration | Component | main-map', function(hooks) {
         layerGroups=this.layerGroups
         layerGroupsMeta=this.meta
         bookmarks=this.bookmarks
-        print=this.print
+        onPrint=(action (mut this.printSvc.enabled) true)
       }}
     `);
 
@@ -141,7 +141,7 @@ module('Integration | Component | main-map', function(hooks) {
         layerGroups=this.layerGroups
         layerGroupsMeta=this.meta
         bookmarks=this.bookmarks
-        print=this.print
+        onPrint=(action (mut this.printSvc.enabled) true)
       }}
     `);
 
@@ -190,7 +190,7 @@ module('Integration | Component | main-map', function(hooks) {
           layerGroups=this.layerGroups
           layerGroupsMeta=this.meta
           bookmarks=this.bookmarks
-          print=this.print
+          onPrint=(action (mut this.printSvc.enabled) true)
           draw=this.draw
         }}
       `);
@@ -239,7 +239,7 @@ module('Integration | Component | main-map', function(hooks) {
           layerGroups=this.layerGroups
           layerGroupsMeta=this.meta
           bookmarks=this.bookmarks
-          print=this.print
+          onPrint=(action (mut this.printSvc.enabled) true)
           draw=this.draw
         }}
       `);
@@ -282,7 +282,7 @@ module('Integration | Component | main-map', function(hooks) {
           layerGroups=this.layerGroups
           layerGroupsMeta=this.meta
           bookmarks=this.bookmarks
-          print=this.print
+          onPrint=(action (mut this.printSvc.enabled) true)
           draw=this.draw
         }}
       `);
@@ -359,7 +359,7 @@ module('Integration | Component | main-map', function(hooks) {
           layerGroups=this.layerGroups
           layerGroupsMeta=this.meta
           bookmarks=this.bookmarks
-          print=this.print
+          onPrint=(action (mut this.printSvc.enabled) true)
         }}
       `);
 
@@ -381,7 +381,7 @@ module('Integration | Component | main-map', function(hooks) {
           layerGroups=this.layerGroups
           layerGroupsMeta=this.meta
           bookmarks=this.bookmarks
-          print=this.print
+          onPrint=(action (mut this.printSvc.enabled) true)
         }}
       `);
 
@@ -403,7 +403,7 @@ module('Integration | Component | main-map', function(hooks) {
           layerGroups=this.layerGroups
           layerGroupsMeta=this.meta
           bookmarks=this.bookmarks
-          print=this.print
+          onPrint=(action (mut this.printSvc.enabled) true)
         }}
       `);
 
@@ -425,7 +425,7 @@ module('Integration | Component | main-map', function(hooks) {
           layerGroups=this.layerGroups
           layerGroupsMeta=this.meta
           bookmarks=this.bookmarks
-          print=this.print
+          onPrint=(action (mut this.printSvc.enabled) true)
         }}
       `);
 
@@ -447,7 +447,7 @@ module('Integration | Component | main-map', function(hooks) {
           layerGroups=this.layerGroups
           layerGroupsMeta=this.meta
           bookmarks=this.bookmarks
-          print=this.print
+          onPrint=(action (mut this.printSvc.enabled) true)
         }}
       `);
 
@@ -469,7 +469,7 @@ module('Integration | Component | main-map', function(hooks) {
           layerGroups=this.layerGroups
           layerGroupsMeta=this.meta
           bookmarks=this.bookmarks
-          print=this.print
+          onPrint=(action (mut this.printSvc.enabled) true)
         }}
       `);
 

--- a/tests/integration/components/print-view-controls-test.js
+++ b/tests/integration/components/print-view-controls-test.js
@@ -7,16 +7,14 @@ module('Integration | Component | print-view-controls', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-
-    await render(hbs`{{print-view-controls}}`);
-
+    this.printSvc = this.owner.lookup('service:print');
+    await render(hbs`{{print-view-controls printSvc=this.printSvc}}`);
     assert.ok(true);
   });
 
   test('it renders with default state', async function(assert) {
-    await render(hbs`{{print-view-controls}}`);
+    this.printSvc = this.owner.lookup('service:print');
+    await render(hbs`{{print-view-controls printSvc=printSvc}}`);
 
     assert.ok(!find('[data-test-print-control="landscape"] .a11y-orange'));
     assert.ok(find('[data-test-print-control="portrait"] .a11y-orange'));
@@ -31,7 +29,8 @@ module('Integration | Component | print-view-controls', function(hooks) {
   });
 
   test('it changes orientation', async function(assert) {
-    await render(hbs`{{print-view-controls}}`);
+    this.printSvc = this.owner.lookup('service:print');
+    await render(hbs`{{print-view-controls printSvc=printSvc}}`);
 
     await click('[data-test-print-control="landscape"]');
 
@@ -45,8 +44,8 @@ module('Integration | Component | print-view-controls', function(hooks) {
   });
 
   test('it changes size', async function(assert) {
-    await render(hbs`{{print-view-controls}}`);
-
+    this.printSvc = this.owner.lookup('service:print');
+    await render(hbs`{{print-view-controls printSvc=printSvc}}`);
     await click('[data-test-print-control="legal"]');
 
     assert.ok(!find('[data-test-print-control="letter"] .a11y-orange'));
@@ -67,7 +66,8 @@ module('Integration | Component | print-view-controls', function(hooks) {
   });
 
   test('it changes what to show and hide', async function(assert) {
-    await render(hbs`{{print-view-controls}}`);
+    this.printSvc = this.owner.lookup('service:print');
+    await render(hbs`{{print-view-controls printSvc=printSvc}}`);
 
     await click('[data-test-print-control="map"]');
 

--- a/tests/unit/services/print-test.js
+++ b/tests/unit/services/print-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | print', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const service = this.owner.lookup('service:print');
+    assert.ok(service);
+  });
+
+  test('printViewHiddenAreas computed property returns correct classes', function(assert) {
+    const printSvc = this.owner.lookup('service:print');
+    assert.equal(printSvc.printViewHiddenAreas, '', 'printViewHiddenAreas default value is okay');
+    printSvc.set('printViewShowMap', false);
+    printSvc.set('printViewShowLegend', false);
+    assert.equal(printSvc.printViewHiddenAreas, 'no-map no-legend', 'printViewHiddenAreas observes changes to ShowMap and ShowLegend');
+    printSvc.set('printViewShowContent', false);
+    assert.equal(printSvc.printViewHiddenAreas, 'no-map no-legend no-content', 'printViewHiddenAreas observes changes to ShowContent, too');
+  });
+
+  test('printViewClasses computed property returns correct classes', function(assert) {
+    const printSvc = this.owner.lookup('service:print');
+    assert.equal(printSvc.printViewClasses, '', 'printViewClasses is blank when print disabled');
+    printSvc.set('enabled', true);
+    assert.equal(printSvc.printViewClasses, 'paper letter portrait ', 'printViewClasses default value is okay');
+    printSvc.set('printViewOrientation', 'landscape');
+    assert.equal(printSvc.printViewClasses, 'paper letter landscape ', 'printViewClasses observes changes to printViewOrientation');
+    printSvc.set('printViewPaperSize', 'tabloid');
+    assert.equal(printSvc.printViewClasses, 'paper tabloid landscape ', 'printViewClasses observes changes to printViewPaperSize');
+    printSvc.set('printViewShowContent', false);
+    assert.equal(printSvc.printViewClasses, 'paper tabloid landscape no-content', 'printViewClasses observes changes to printViewHiddenAreas');
+  });
+});


### PR DESCRIPTION
## what
- Moves print concerns out of the application controller and into a print service.
- Hooks up  the `main-map`, `main-header` and `print-view-controls` components to the service.
- Adds unit tests for the service's computed properties to generate print classes.

## Entrypoint 
`app/controllers/application.js` line 52, where the print service replaced original print concerns.
and then `app/services/print.js`.

## questions
Since `print-view-controls` component is so tightly coupled to the print service, I'm actually thinking that may be made more explicit if I leave the component parameters on `print-view-controls`. E.g.
```
    <PrintViewControls
      @print={{print.enabled}}
      @printViewOrientation={{print.printViewOrientation}}
      @printViewPaperSize={{print.printViewPaperSize}}
      @printViewShowMap={{print.printViewShowMap}}
      @printViewShowLegend={{print.printViewShowLegend}}
      @printViewShowContent={{print.printViewShowContent}}
    />
```

Thoughts? This is probably a super minor style thing, though. 

## Riders
- note use of yarn in readme.