### PR TITLE
Hotfix legacy model name

### DIFF
--- a/app/serializers/bookmark.js
+++ b/app/serializers/bookmark.js
@@ -1,1 +1,16 @@
-export { default } from 'ember-local-storage/serializers/serializer';
+import LocalStorageSerializer from 'ember-local-storage/serializers/serializer';
+import { get } from '@ember/object';
+
+export default LocalStorageSerializer.extend({
+  normalizeFindAllResponse(store, primaryModelClass, payload, ...args) {
+    payload.data.forEach((record) => {
+      if (record.relationships) {
+        if (get(record, 'relationships.bookmark.data.type') === 'zmas') {
+          record.relationships.bookmark.data.type = 'zoning-map-amendment';
+        }
+      }
+    });
+
+    return this._super(store, primaryModelClass, payload, ...args);
+  },
+});

--- a/tests/acceptance/bookmarks-test.js
+++ b/tests/acceptance/bookmarks-test.js
@@ -179,4 +179,32 @@ module('Acceptance | bookmarks', function(hooks) {
     assert.ok(find('[data-test-bookmark="test-1"]'));
     assert.ok(find('[data-test-bookmark="test-2"]'));
   });
+
+  test('it works with legacy records', async function(assert) {
+    this.server.create('carto-geojson-feature', {
+      id: '050111azmk',
+    });
+
+    localStorageSetStringified('bookmarks-1', {
+      id: 'test',
+      attributes: {
+        address: null,
+      },
+      relationships: {
+        bookmark: {
+          data: {
+            type: 'zmas',
+            id: '050111azmk',
+          },
+        },
+      },
+      type: 'bookmarks',
+    });
+
+    localStorageSetStringified('index-bookmarks', ['bookmarks-1']);
+
+    await visit('/bookmarks');
+
+    assert.ok(true);
+  });
 });


### PR DESCRIPTION
ZMA model was renamed to zoning-map-amendment. This means that old local storages that _might have had_ a zma bookmarked will fail because their local storage contains references to models of an unrecognized type.

This patch simply converts the old name.