### PR TITLE
Re-enables bookmarked lot outlines, incl test

### DIFF
--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -64,7 +64,7 @@ export default class MainMap extends Component {
   @computed('bookmarks.[]')
   get bookmarkedLotsLayer() {
     const bookmarks = this.get('bookmarks.[]');
-    const lotBookmarks = bookmarks.getEach('bookmark.bbl')
+    const lotBookmarks = bookmarks.getEach('bookmark.properties.bbl')
       .filter(d => d); // filter out bookmarks with undefined bbl
 
     const filter = ['match', ['get', 'bbl'], lotBookmarks, true, false];

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -40,10 +40,10 @@
       />
     </layers.tooltip>
   </LabsLayers>
-  {{#if bookmarkedLotsLayer}}
+  {{#if this.bookmarkedLotsLayer}}
     <MapboxGlLayer
       @map={{map.instance}}
-      @layer={{bookmarkedLotsLayer}}
+      @layer={{this.bookmarkedLotsLayer}}
       @before="place_other"
     />
   {{/if}}


### PR DESCRIPTION
Closes #894 by fixing a regression with outlining bookmarked lots.

This adds a test for the feature as well.