### PR TITLE
Add load spinner in top left of map;

### DIFF
--- a/app/components/mapbox/load-spinner.js
+++ b/app/components/mapbox/load-spinner.js
@@ -1,0 +1,18 @@
+import Component from '@ember/component';
+import { action } from '@ember/object';
+import { timeout } from 'ember-concurrency';
+import { restartableTask } from 'ember-concurrency-decorators';
+
+export default class LoadSpinner extends Component {
+  mapInstance = {};
+
+  @restartableTask
+  loadStateTask = function* () {
+    yield timeout(500);
+  };
+
+  @action
+  handleMapLoading() {
+    this.get('loadStateTask').perform();
+  }
+}

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -199,3 +199,12 @@
   box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
   border-radius: 2px;
 }
+
+.map-loading-spinner {
+  margin-top: 155px;
+  margin-left: 8px;
+  opacity: 0.5;
+  z-index: 1;
+  pointer-events: none;
+}
+

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -15,6 +15,7 @@
     class="labs-map-loaded"
     style="display:none"
   ></div>
+
   <div class="print-controls mapboxgl-ctrl mapboxgl-ctrl-group">
     <button
       class="mapboxgl-ctrl-icon"
@@ -24,6 +25,7 @@
       {{fa-icon "print"}}
     </button>
   </div>
+
   <LabsLayers
     @map={{map.instance}}
     @hoveredFeature={{map.hoveredFeature}}
@@ -40,6 +42,7 @@
       />
     </layers.tooltip>
   </LabsLayers>
+
   {{#if this.bookmarkedLotsLayer}}
     <MapboxGlLayer
       @map={{map.instance}}
@@ -47,6 +50,7 @@
       @before="place_other"
     />
   {{/if}}
+
   {{#if mainMap.selected}}
     <MapboxGlSource
       @map={{map.instance}}
@@ -57,6 +61,11 @@
       <source.layer @layer={{selectedLineLayer}} @before="place_other" />
     </MapboxGlSource>
   {{/if}}
+
+  <Mapbox::LoadSpinner
+    @map={{map.instance}}
+  />
+
   <MapMeasurementTools
     @map={{map.instance}}
     @draw={{this.draw}} as |measurement|
@@ -80,6 +89,6 @@
       </MapboxGlSource>
     {{/if}}
   </MapMeasurementTools>
-  {{mapbox-gl-on "data" (action "mapLoading") eventSource=map.instance}}
 </Mapbox::BasicMap>
-{{locate-me-mobile}}
+
+<LocateMeMobile />

--- a/app/templates/components/mapbox/load-spinner.hbs
+++ b/app/templates/components/mapbox/load-spinner.hbs
@@ -1,0 +1,7 @@
+{{#if loadStateTask.isRunning}}
+  {{fa-icon 'spinner' class='fa-spin fa-3x map-loading-spinner'}}
+{{/if}}
+
+{{mapbox-gl-on "render" (action "handleMapLoading") eventSource=map}}
+{{mapbox-gl-on "data" (action "handleMapLoading") eventSource=map}}
+{{mapbox-gl-on "sourcedata" (action "handleMapLoading") eventSource=map}}

--- a/tests/integration/components/mapbox/load-spinner-test.js
+++ b/tests/integration/components/mapbox/load-spinner-test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | mapbox/load-spinner', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    this.map = {
+      instance: {
+        on() {},
+        off() {},
+      },
+    };
+
+    await render(hbs`
+      {{mapbox/load-spinner
+        map = map.instance
+      }}
+    `);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+});


### PR DESCRIPTION
Closes #660 

Adds a load spinner to the top left of the map.

Entry point is main-map.hbs - this PR includes a new component that handles the markup and event binding for loading.

@andycochran curious to hear if you have any options about the position of the load spinner. I tried to make it bottom flush right but because we have the information panel on the right positioned _over_ the map, the spinner is hidden.

