### PR TITLE
642 restore zoom dependent warning labels

### DIFF
--- a/app/components/layer-palette.js
+++ b/app/components/layer-palette.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { action } from '@ember/object';
 import { classNames } from '@ember-decorators/component';
 import { next } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 import config from 'labs-zola/config/environment';
 
 const { zoningDistrictOptionSets, commercialOverlaysOptionSets } = config;
@@ -14,6 +15,11 @@ export default class LayerPaletteComponent extends Component {
     this.setFilterForZoning();
     this.setFilterForOverlays();
   }
+
+  @service
+  mainMap
+
+  zoomWarningLabel = 'Some information may not be visible at this zoom level.';
 
   selectedZoning = [];
 

--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -175,6 +175,10 @@ export default class MainMap extends Component {
       type: 'raster',
       minzoom: 17,
     });
+
+    map.on('zoom', function() {
+      mainMap.set('zoom', map.getZoom());
+    });
   }
 
   @action

--- a/app/helpers/zoom-dependent-label.js
+++ b/app/helpers/zoom-dependent-label.js
@@ -1,0 +1,16 @@
+import Helper from '@ember/component/helper';
+
+export default Helper.extend({
+
+  compute([layerGroup, label, mapZoom]) {
+    const allMinzooms = layerGroup.layers.map((layer) => {
+      if (layer.style) {
+        return layer.style.minzoom;
+      }
+      return false;
+    }).filter(zoom => !!zoom);
+    const maxOfallMinzooms = (allMinzooms.length) ? Math.max(...allMinzooms) : false;
+    return (mapZoom < maxOfallMinzooms) ? label : null;
+  },
+
+});

--- a/app/services/main-map.js
+++ b/app/services/main-map.js
@@ -23,6 +23,8 @@ export default class MainMapService extends Service {
 
   routeIntentIsNested = false;
 
+  zoom = DEFAULT_ZOOM;
+
   knownHashIntent = '';
 
   @computed
@@ -32,16 +34,6 @@ export default class MainMapService extends Service {
     }
 
     return [9.72, 40.7125, -73.733];
-  }
-
-  @computed
-  get zoom() {
-    if (this.knownHashIntent) {
-      const [,, z] = this.parsedHash;
-      return z;
-    }
-
-    return DEFAULT_ZOOM;
   }
 
   @computed

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -17,6 +17,7 @@
     <container.layer-group-toggle
       data-test-toggle-tax-lots
       @layerGroup={{this.layerGroups.tax-lots}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.tax-lots this.zoomWarningLabel this.mainMap.zoom}}
     >
       <label
         class="checkbox-wrapper"
@@ -64,6 +65,7 @@
     <container.layer-group-toggle
       data-test-toggle-zoning-districts
       @layerGroup={{this.layerGroups.zoning-districts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.zoning-districts this.zoomWarningLabel this.mainMap.zoom}}
     >
       <ul class="layer-menu-item--group-checkboxes">
         {{#each this.zoningDistrictOptionSets as |optionSet|}}
@@ -80,6 +82,7 @@
     <container.layer-group-toggle
       data-test-toggle-commercial-overlays
       @layerGroup={{this.layerGroups.commercial-overlays}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.commercial-overlays this.zoomWarningLabel this.mainMap.zoom}}
     >
       <ul class="layer-menu-item--group-checkboxes">
         {{#each this.commercialOverlaysOptionSets as |optionSet|}}
@@ -96,6 +99,7 @@
     <container.layer-group-toggle
       data-test-toggle-zoning-map-amendments
       @layerGroup={{this.layerGroups.zoning-map-amendments}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.zoning-map-amendments this.zoomWarningLabel this.mainMap.zoom}}
     >
       <LayerControlTimeline
         @layerGroup={{this.layerGroups.zoning-map-amendments}}
@@ -106,14 +110,17 @@
     <container.layer-group-toggle
       data-test-toggle-zoning-map-amendments-pending
       @layerGroup={{this.layerGroups.zoning-map-amendments-pending}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.zoning-map-amendments-pending this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-special-purpose-districts
       @layerGroup={{this.layerGroups.special-purpose-districts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.special-purpose-districts this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-special-purpose-subdistricts
       @layerGroup={{this.layerGroups.special-purpose-subdistricts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.special-purpose-subdistricts this.zoomWarningLabel this.mainMap.zoom}}
     />
   </LabsUi::LayerGroupsContainer>
   <LabsUi::LayerGroupsContainer
@@ -123,56 +130,68 @@
     <container.layer-group-toggle
       data-test-toggle-mandatory-inclusionary-housing
       @layerGroup={{this.layerGroups.mandatory-inclusionary-housing}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.mandatory-inclusionary-housing this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-inclusionary-housing
       @layerGroup={{this.layerGroups.inclusionary-housing}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.inclusionary-housing this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-transit-zones
       @layerGroup={{this.layerGroups.transit-zones}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.transit-zones this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-fresh
       @layerGroup={{this.layerGroups.fresh}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.fresh this.zoomWarningLabel this.mainMap.zoom}}
     >
       <LabsUi::LegendItems @items={{this.layerGroups.fresh.legend.items}} />
     </container.layer-group-toggle>
     <container.layer-group-toggle
       data-test-toggle-sidewalk-cafes
       @layerGroup={{this.layerGroups.sidewalk-cafes}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.sidewalk-cafes this.zoomWarningLabel this.mainMap.zoom}}
     >
       <LabsUi::LegendItems @items={{this.layerGroups.sidewalk-cafes.legend.items}} />
     </container.layer-group-toggle>
     <container.layer-group-toggle
       data-test-toggle-limited-height-districts
       @layerGroup={{this.layerGroups.limited-height-districts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.limited-height-districts this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-low-density-growth-mgmt-areas
       @layerGroup={{this.layerGroups.low-density-growth-mgmt-areas}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.low-density-growth-mgmt-areas this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-coastal-zone-boundary
       @layerGroup={{this.layerGroups.coastal-zone-boundary}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.coastal-zone-boundary this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-waterfront-access-plan
       @layerGroup={{this.layerGroups.waterfront-access-plan}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.waterfront-access-plan this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-historic-districts
       @layerGroup={{this.layerGroups.historic-districts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.historic-districts this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-landmarks
       @layerGroup={{this.layerGroups.landmarks}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.landmarks this.zoomWarningLabel this.mainMap.zoom}}
     >
       <LabsUi::LegendItems @items={{this.layerGroups.landmarks.legend.items}} />
     </container.layer-group-toggle>
     <container.layer-group-toggle
       data-test-toggle-floodplain-efirm2007
       @layerGroup={{this.layerGroups.floodplain-efirm2007}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.floodplain-efirm2007 this.zoomWarningLabel this.mainMap.zoom}}
     >
       <LabsUi::LegendItems
         @items={{this.layerGroups.floodplain-efirm2007.legend.items}}
@@ -181,6 +200,7 @@
     <container.layer-group-toggle
       data-test-toggle-floodplain-pfirm2015
       @layerGroup={{this.layerGroups.floodplain-pfirm2015}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.floodplain-pfirm2015 this.zoomWarningLabel this.mainMap.zoom}}
     >
       <LabsUi::LegendItems
         @items={{this.layerGroups.floodplain-pfirm2015.legend.items}}
@@ -189,12 +209,14 @@
     <container.layer-group-toggle
       data-test-toggle-e-designations
       @layerGroup={{this.layerGroups.e-designations}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.e-designations this.zoomWarningLabel this.mainMap.zoom}}
     >
       <LabsUi::LegendItem @item={{this.layerGroups.e-designations.legend}} />
     </container.layer-group-toggle>
     <container.layer-group-toggle
       data-test-toggle-appendixj-designated-mdistricts
       @layerGroup={{this.layerGroups.appendixj-designated-mdistricts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.appendixj-designated-mdistricts this.zoomWarningLabel this.mainMap.zoom}}
     />
   </LabsUi::LayerGroupsContainer>
   <LabsUi::LayerGroupsContainer
@@ -204,10 +226,12 @@
     <container.layer-group-toggle
       data-test-toggle-business-improvement-districts
       @layerGroup={{this.layerGroups.business-improvement-districts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.business-improvement-districts this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-industrial-business-zones
       @layerGroup={{this.layerGroups.industrial-business-zones}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.industrial-business-zones this.zoomWarningLabel this.mainMap.zoom}}
     />
   </LabsUi::LayerGroupsContainer>
   <LabsUi::LayerGroupsContainer
@@ -217,26 +241,32 @@
     <container.layer-group-toggle
       data-test-toggle-boroughs
       @layerGroup={{this.layerGroups.boroughs}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.boroughs this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-community-districts
       @layerGroup={{this.layerGroups.community-districts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.community-districts this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-nyc-council-districts
       @layerGroup={{this.layerGroups.nyc-council-districts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.nyc-council-districts this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-ny-senate-districts
       @layerGroup={{this.layerGroups.ny-senate-districts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.ny-senate-districts this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-assembly-districts
       @layerGroup={{this.layerGroups.assembly-districts}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.assembly-districts this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-neighborhood-tabulation-areas
       @layerGroup={{this.layerGroups.neighborhood-tabulation-areas}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.neighborhood-tabulation-areas this.zoomWarningLabel this.mainMap.zoom}}
     />
   </LabsUi::LayerGroupsContainer>
   <LabsUi::LayerGroupsContainer
@@ -246,14 +276,17 @@
     <container.layer-group-toggle
       data-test-toggle-subway
       @layerGroup={{this.layerGroups.subway}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.subway this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-building-footprints
       @layerGroup={{this.layerGroups.building-footprints}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.building-footprints this.zoomWarningLabel this.mainMap.zoom}}
     />
     <container.layer-group-toggle
       data-test-toggle-three-d-buildings
       @layerGroup={{this.layerGroups.three-d-buildings}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.three-d-buildings this.zoomWarningLabel this.mainMap.zoom}}
     >
       <ul class="layer-key">
         <li>
@@ -277,6 +310,7 @@
     <container.layer-group-toggle
       data-test-toggle-aerials
       @layerGroup={{this.layerGroups.aerials}}
+      @activeTooltip={{zoom-dependent-label this.layerGroups.aerials this.zoomWarningLabel this.mainMap.zoom}}
     >
       <ul class="layer-menu-item--group-checkboxes no-bullet list-float-3">
         {{#each layerGroups.aerials.layers as |layer|}}

--- a/tests/integration/helpers/zoom-dependent-label-test.js
+++ b/tests/integration/helpers/zoom-dependent-label-test.js
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | zoom-dependent-label', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it returns correct warning label based on current map zoom', async function(assert) {
+    this.mockLayerGroup = {
+      layers: [
+        {
+          style: { minzoom: 4 },
+        },
+        {
+          style: { minzoom: 12 },
+        },
+        {},
+        {
+          style: {},
+        },
+      ],
+    };
+
+    await render(hbs`{{zoom-dependent-label this.mockLayerGroup "Warning" 10}}`);
+
+    assert.equal(this.element.textContent.trim(), 'Warning');
+
+    await render(hbs`{{zoom-dependent-label this.mockLayerGroup "Warning" 14}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+});


### PR DESCRIPTION
## What 

Restores zoom dependent warnings.

## How

Takes advantage of @andycochran 's `activeTooltip` parameter on the `layer-group-toggle` component. 

Created a new helper to either return a null value or the warning label to `activeTooltip`. For a given layer group, the helper returns null when the map zoom is higher than all sublayers' minzoom, otherwise it returns a message about possible missing information.  

## Riders
Detached the `main-map` service's `zoom` property from the app url hash. 