### PR TITLE
930: Clarify Google Analytics event labels

### DIFF
--- a/app/components/map-resource-search.js
+++ b/app/components/map-resource-search.js
@@ -46,7 +46,7 @@ export default class MapResourceSearchComponent extends Component {
       // GA
       this.get('metrics').trackEvent('GoogleAnalytics', {
         eventCategory: 'Search',
-        eventAction: 'Used Search Bar',
+        eventAction: 'Searched by Address',
       });
 
       const { boro, block, lot } = bblDemux(result.bbl);

--- a/app/services/print.js
+++ b/app/services/print.js
@@ -34,7 +34,7 @@ export default class PrintService extends Service {
     // GA
     this.get('metrics').trackEvent('GoogleAnalytics', {
       eventCategory: 'Print',
-      eventAction: `${this.enabled ? 'Enabled print view' : null}`,
+      eventAction: `${this.enabled ? 'Enabled print view' : ''}`,
       eventLabel: 'export',
     });
 


### PR DESCRIPTION
This PR renames the "Used Search Bar" event as "Searched by Address" and a null event as an empty string.