### PR TITLE
Make Cyclomedia a hyperlink

### DIFF
--- a/app/components/road-view.js
+++ b/app/components/road-view.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import InViewportMixin from 'ember-in-viewport';
+import { computed } from '@ember/object';
 
 export default class RoadView extends Component.extend(InViewportMixin) {
   lat;
@@ -7,4 +8,9 @@ export default class RoadView extends Component.extend(InViewportMixin) {
   lon;
 
   inView = false;
+
+  @computed('lon', 'lat')
+  get url() {
+    return `https://roadview.planninglabs.nyc/view/${this.lon}/${this.lat}`;
+  }
 }

--- a/app/templates/components/road-view.hbs
+++ b/app/templates/components/road-view.hbs
@@ -1,10 +1,18 @@
 <div class="cyclomedia hide-for-print">
-  {{#if inView}}
+  {{#if (and this.inView (media "desktop"))}}
     <iframe
-      src="https://roadview.planninglabs.nyc/view/{{lon}}/{{lat}}"
+      src={{this.url}}
       class="cyclomedia"
       allowfullscreen=""
     ></iframe>
+  {{else}}
+    <a
+      class="button gray large reset-map-button hide-for-print"
+      href={{this.url}}
+      target="_blank"
+    >
+      {{fa-icon "external-link-alt"}} View Cyclomedia
+    </a>
   {{/if}}
 </div>
-<IsInViewport @inView={{inView}} />
+<IsInViewport @inView={{this.inView}} />


### PR DESCRIPTION
Makes the Cyclomedia view in the tax-lot detail page a hyperlink if the user is on a mobile or tablet device.

Should address #455 and closes #936.