### PR TITLE
Loading spinner works for all stages of map

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -60,6 +60,9 @@ export default class ApplicationController extends Controller.extend(mapQueryPar
   @service
   fastboot;
 
+  @service
+  mainMap;
+
   // this action extracts query-param-friendly state of layer groups
   // for various paramable layers
   @action

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -201,10 +201,21 @@
 }
 
 .map-loading-spinner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0.5;
+  z-index: 100;
+  pointer-events: none;
   margin-top: 155px;
   margin-left: 8px;
-  opacity: 0.5;
-  z-index: 1;
-  pointer-events: none;
+
+  @include breakpoint(large) {
+    left: 15rem;
+  }
+  @include breakpoint(xlarge) {
+    left: 18rem;
+  }
+
 }
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -10,6 +10,9 @@
     <div class="navigation-area cell large-auto">
       <MapResourceSearch />
       <div class="map-grid">
+        <Mapbox::LoadSpinner
+          @map={{this.mainMap.mapInstance}}
+        />
         {{!-- 
           Prevent the map from loading if it's in fastboot. Right now, we don't have a good way
           to pre-render a map in node. For / and about /about views, this doesn't matter as much.

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -62,10 +62,6 @@
     </MapboxGlSource>
   {{/if}}
 
-  <Mapbox::LoadSpinner
-    @map={{map.instance}}
-  />
-
   <MapMeasurementTools
     @map={{map.instance}}
     @draw={{this.draw}} as |measurement|

--- a/app/templates/components/mapbox/load-spinner.hbs
+++ b/app/templates/components/mapbox/load-spinner.hbs
@@ -1,7 +1,9 @@
-{{#if loadStateTask.isRunning}}
+{{#if (or loadStateTask.isRunning (not map))}}
   {{fa-icon 'spinner' class='fa-spin fa-3x map-loading-spinner'}}
 {{/if}}
 
-{{mapbox-gl-on "render" (action "handleMapLoading") eventSource=map}}
-{{mapbox-gl-on "data" (action "handleMapLoading") eventSource=map}}
-{{mapbox-gl-on "sourcedata" (action "handleMapLoading") eventSource=map}}
+{{#if this.map}}
+  {{mapbox-gl-on "render" (action "handleMapLoading") eventSource=map}}
+  {{mapbox-gl-on "data" (action "handleMapLoading") eventSource=map}}
+  {{mapbox-gl-on "sourcedata" (action "handleMapLoading") eventSource=map}}
+{{/if}}


### PR DESCRIPTION
This PR moves the map load spinner up in the component hierarchy so that it is visible before the map has even begun drawing in order convey that the map itself is instantiating first.

This became more apparent after pre-rendered content was introduced because the map does not get pre-rendered.

Closes #940 