### PR TITLE
Prevent dynamic-sensitive content

### DIFF
--- a/app/components/labs-ui/layer-group-toggle.js
+++ b/app/components/labs-ui/layer-group-toggle.js
@@ -1,9 +1,13 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 import layout from '../../templates/components/labs-ui/layer-group-toggle';
 
 export default class LayerGroupToggle extends Component {
+  @service
+  fastboot;
+
   // ember component class options
   classNames = ['layer-group-toggle'];
 

--- a/app/templates/components/labs-ui/layer-group-toggle.hbs
+++ b/app/templates/components/labs-ui/layer-group-toggle.hbs
@@ -1,12 +1,14 @@
 <div class="layer-group-toggle-header layer-{{dasherize label}}">
   <div class="grid-x">
     <div class="cell auto ">
-      <div class="switch tiny float-left">
-        <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
-        <label {{action 'toggle'}} class="switch-paddle">
-          <span class="show-for-sr">Toggle Layer Group</span>
-        </label>
-      </div>
+      {{#if (not fastboot.isFastBoot)}}
+        <div class="switch tiny float-left">
+          <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
+          <label {{action 'toggle'}} class="switch-paddle">
+            <span class="show-for-sr">Toggle Layer Group</span>
+          </label>
+        </div>
+      {{/if}}
       <span {{action 'toggle' preventDefault=false}} class="layer-group-toggle-label" role="button">
         {{label}}
         {{#if active}}
@@ -45,6 +47,8 @@
 </div>
 {{#if active}}
   <div class="layer-group-toggle-content">
-    {{yield}}
+    {{#if (not fastboot.isFastBoot)}}
+      {{yield}}
+    {{/if}}
   </div>
 {{/if}}

--- a/app/templates/components/main-header.hbs
+++ b/app/templates/components/main-header.hbs
@@ -11,7 +11,9 @@
     }}
       ZoLa
       <small class="site-subtitle show-for-medium">
-        {{#if (media "desktop")}}
+        {{#if (or (this.media "mobile") (this.media "tablet"))}}
+          NYC's 
+        {{else}}
           <span class="show-for-large">
             New
           </span>
@@ -21,9 +23,6 @@
           <span class="show-for-large">
             City's
           </span>
-        {{/if}}
-        {{#if (or (media "mobile") (media "tablet"))}}
-          NYC's 
         {{/if}}
         Zoning &amp; Land Use Map
       </small>


### PR DESCRIPTION
This PR closes #942 by preventing query-parameter-sensitive markup from being loaded in fastboot.

The reason for doing this is that the initial load can flash the "wrong" state (the default state) if query params are loaded (see canary site for comparison).

This also defaults the site header text to desktop mode in the absence of information about the user agent's screen.