### PR TITLE
Refactor & style AnnouncementBox

### DIFF
--- a/app/components/announcement-box.js
+++ b/app/components/announcement-box.js
@@ -1,11 +1,7 @@
 import Component from '@ember/component';
-import { action } from '@ember/object';
+import { classNames, tagName } from '@ember-decorators/component';
 
+@classNames('show-for-large')
+@tagName('li')
 export default class AnnouncementBox extends Component {
-  isOpen = false;
-
-  @action
-  toggle() {
-    this.toggleProperty('isOpen');
-  }
 }

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -4,6 +4,7 @@ import { computed, action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import QueryParams from 'ember-parachute';
 import config from 'labs-zola/config/environment';
+import 'what-input';
 
 const {
   defaultLayerGroupState,

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -118,7 +118,6 @@ body.index {
   }
 }
 
-// .search-and-layers {
 .layer-palette {
   @include xy-cell-static(full,false,0);
   position: relative;
@@ -249,7 +248,101 @@ body.index {
   }
 }
 
-.announcement-box {
-  padding: $global-margin;
+// Announcements
+.site-header .menu button { // should be added to Labs UI
+  color: #5d626a;
+  line-height: 1.5;
+  padding: 1.6875rem 1.25rem;
+  font-size: 0.875rem;
+  font-weight: bold;
+  display: block;
+
+  &:hover {
+    background-color: #ecedee;
+    color: #212326;
+  }
 }
 
+
+// EmberTooltip overrides -
+// There is no `.ember-tooltip-arrow` in popovers; they have `.ember-popover-arrow`
+// and `.tooltip-arrow`. So popovers don't get arrows.
+//
+// TODO: [x] PR for Ember Tooltips (#370) to fix .ember-tooltip-arrow -> .tooltip-arrow issue
+// TODO: [ ] PR for Labs UI to fix colors
+// TODO: [ ] Remove these overrides onces dependency PRs are merged/published
+.ember-popover-arrow {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  position: absolute;
+  margin: 5px;
+  border: 5px solid transparent;
+}
+
+.ember-popover[x-placement^="top"] .tooltip-arrow {
+  border-bottom-width: 0;
+  bottom: -5px;
+  left: calc(50% - 5px);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.ember-popover[x-placement^="top"] .tooltip-arrow {
+  border-top-color: $white-smoke;
+}
+.ember-popover.dark[x-placement^="top"] .tooltip-arrow {
+  border-top-color: $charcoal;
+}
+
+.ember-popover[x-placement^="right"] .tooltip-arrow {
+  border-left-width: 0;
+  left: -5px;
+  top: calc(50% - 5px);
+  margin-right: 0;
+  margin-left: 0;
+}
+
+.ember-popover[x-placement^="right"] .tooltip-arrow {
+  border-right-color: $white-smoke;
+}
+.ember-popover.dark[x-placement^="right"] .tooltip-arrow {
+  border-right-color: $charcoal;
+}
+
+.ember-popover[x-placement^="bottom"] .tooltip-arrow {
+  border-top-width: 0;
+  top: -5px;
+  left: calc(50% - 5px);
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.ember-popover[x-placement^="bottom"] .tooltip-arrow {
+  border-bottom-color: $white-smoke;
+}
+.ember-popover.dark[x-placement^="bottom"] .tooltip-arrow {
+  border-bottom-color: $charcoal;
+}
+
+.ember-popover[x-placement^="left"] .tooltip-arrow {
+  border-right-width: 0;
+  right: -5px;
+  top: calc(50% - 5px);
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.ember-popover[x-placement^="left"] .tooltip-arrow {
+  border-left-color: $white-smoke;
+}
+.ember-popover.dark[x-placement^="left"] .tooltip-arrow {
+  border-left-color: $charcoal;
+}
+
+.ember-popover-inner {
+  max-width: rem-calc(400);
+}
+.ember-popover.dark {
+  box-shadow: 0 0 0 4px rgba(0,0,0,0.1);
+}

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -6,20 +6,6 @@
   {{/link-to}}
 </div>
 <div class="content-area cell large-5 large-cell-block-y xxlarge-4">
-  <AnnouncementBox
-    @title="Improvements are on the way!"
-  >
-    <p class="text-small">
-      We apologize for recent service interruptions and hope that you'll observe some upcoming performance upgrades.
-    </p>
-    <p class="text-small">
-      Thank you!
-    </p>
-    <p class="text-small">
-      — <a href="mailto:zola_gis@planning.nyc.gov"> NYC Planning Labs</a>
-    </p>
-  </AnnouncementBox>
-
   <h1 class="header-xlarge">
     Welcome to New York&nbsp;City's zoning &amp; land&nbsp;use&nbsp;map.
   </h1>

--- a/app/templates/components/announcement-box.hbs
+++ b/app/templates/components/announcement-box.hbs
@@ -1,14 +1,18 @@
-<div
-  class="button expanded tiny text-left no-margin"
-  style="text-align: left;"
-  onclick={{action this.toggle}}
->
-  {{fa-icon 'bullhorn'}}
-  Announcement: {{this.title}}
-</div>
-
-{{#if this.isOpen}}
-  <div class="announcement-box" style="background-color: #ecedee">
-    {{yield}}
-  </div>
-{{/if}}
+<button>
+  {{fa-icon "bell"}} <sup class="a11y-orange">NEW!</sup>
+  <EmberPopover
+    @side="bottom-end"
+    @event='click'
+    @tooltipClassName='ember-popover dark'
+    @popperContainer='body'
+    as |popover|
+  >
+    <p class="text-small">
+      We've been working on ZoLa to prevent service interruptions. With these upgrades, you should now notice performance improvement.
+    </p>
+    <p class="text-small">
+      Thank you for using ZoLa!
+      <br>—<a href="mailto:zola_gis@planning.nyc.gov"> NYC Planning Labs</a>
+    </p>
+  </EmberPopover>
+</button>

--- a/app/templates/components/main-header.hbs
+++ b/app/templates/components/main-header.hbs
@@ -23,7 +23,7 @@
           </span>
         {{/if}}
         {{#if (or (media "mobile") (media "tablet"))}}
-          NYC's 
+          NYC's
         {{/if}}
         Zoning &amp; Land Use Map
       </small>
@@ -51,6 +51,7 @@
           {{/if}}
         {{/link-to}}
       </li>
+      <AnnouncementBox />
     </ul>
   </banner.nav>
 </LabsUi::SiteHeader>

--- a/config/environment.js
+++ b/config/environment.js
@@ -223,8 +223,8 @@ module.exports = function(environment) {
         ],
         'free-solid-svg-icons': [
           'angle-up',
+          'bell',
           'bookmark',
-          'bullhorn',
           'caret-down',
           'caret-up',
           'check-square',

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ember-test-helpers": "^0.6.3",
     "ember-test-selectors": "2.0.0",
     "ember-tether": "v1.0.0-beta.3",
-    "ember-tooltips": "^3.1.0",
+    "ember-tooltips": "^3.3.3",
     "ember-truth-helpers": "^2.1.0",
     "ember-unused-components": "0.2.0",
     "ember-window-mock": "0.5.4",
@@ -125,7 +125,8 @@
     "@turf/boolean-within": "^6.0.1",
     "mustache": "3.0.1",
     "node-fetch": "2.6.0",
-    "numeral": "^2.0.6"
+    "numeral": "^2.0.6",
+    "what-input": "^5.2.3"
   },
   "resolutions": {
     "ember-composable-helpers": "2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5623,6 +5623,24 @@ ember-tooltips@^3.1.0:
     resolve "^1.10.1"
     tooltip.js "^1.1.5"
 
+ember-tooltips@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ember-tooltips/-/ember-tooltips-3.3.3.tgz#7b25842f1adc977897c9a4ad69b3388d4239942d"
+  integrity sha512-PvibtNZZKNEYFtRes/bJZOefDXIuopgkqF89XFu0ARe10Gu9Mgy5cB9SSI1sP8zp4TampyvA3TOJ/kGJcxlrqA==
+  dependencies:
+    broccoli-file-creator "^2.1.1"
+    broccoli-funnel "^2.0.2"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-source "^2.0.0"
+    broccoli-string-replace "^0.1.2"
+    ember-cli-babel "^6.16.0"
+    ember-cli-htmlbars "^3.0.0"
+    ember-get-config "^0.2.4"
+    ember-wormhole "^0.5.5"
+    popper.js "^1.12.5"
+    resolve "^1.10.1"
+    tooltip.js "^1.1.5"
+
 ember-truth-helpers@^2.0.0, ember-truth-helpers@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz#d4dab4eee7945aa2388126485977baeb33ca0798"
@@ -12963,6 +12981,11 @@ wgs84@0.0.0:
 what-input@^5.0.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/what-input/-/what-input-5.2.1.tgz#db4e25148be78f8edbd2e9e616097c3702d4364f"
+
+what-input@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/what-input/-/what-input-5.2.3.tgz#9e636c9854c875b50b6716facd4fb55deb1d6653"
+  integrity sha512-ekQJmKNVEPcFIE2YI1L7iXm/m2QTQWe9QqewSCCFZs2ZPo3yOfA8TV8ioBx/JnWZrDUNVGj/YdDJCH5uagMEgg==
 
 whatwg-fetch@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- Moves the AnnouncementBox component to the site header so it's available on all routes
- Uses Ember Tooltips instead of custom action to toggle the announcement (added benefit of clicking anywhere on page to close it)
- Adds `what-input` to prevent `:focus` outline styles showing for non-keyboard navigation
- Adds some temporary overrides for Labs UI and Ember Tooltips (should be remove once [this PR](https://github.com/sir-dunxalot/ember-tooltips/pull/370) has been merged/published)
- Updates the language of the announcement to be more friendly/positive 