### PR TITLE
946: add bay street district link

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -129,6 +129,7 @@ module.exports = function(environment) {
       ['Special Long Island City Mixed Use District', ['LIC', 'queens']],
       ['Special Southern Hunters Point District', ['SHP', 'queens']],
       ['Special Willets Point District', ['WP', 'queens']],
+      ['Special Bay Street Corridor District', ['BSC', 'staten-island']],
       ['Special Hillsides Preservation District', ['HS', 'staten-island']],
       ['Special St. George District', ['SG', 'staten-island']],
       ['Special South Richmond Development District', ['SRD', 'staten-island']],


### PR DESCRIPTION
Addresses #946. Adds link lookup for the Special Bay Street Corridor District.