### PR TITLE
New ZMA data and fix slider to filter both lines and fills

### DIFF
--- a/app/components/layer-control-timeline.js
+++ b/app/components/layer-control-timeline.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { ChildMixin } from 'ember-composability-tools';
 
 const defaultMax = new Date();
-const defaultStart = [1032370151000, defaultMax.getTime()];
+const defaultStart = [0, defaultMax.getTime()];
 
 function formatDate(date) {
   const d = new Date(date);

--- a/app/components/layer-control-timeline.js
+++ b/app/components/layer-control-timeline.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { ChildMixin } from 'ember-composability-tools';
 
 const defaultMax = new Date();
-const defaultStart = [0, defaultMax.getTime()];
+const defaultStart = [220924800, defaultMax.getTime()];
 
 function formatDate(date) {
   const d = new Date(date);
@@ -28,12 +28,15 @@ export default Component.extend(ChildMixin, {
   actions: {
     sliderChanged(value) {
       const [min, max] = value;
-      const { layerGroup, layerID, column } = this;
+      const { layerGroup, column } = this;
 
       this.set('start', value);
 
       const expression = ['all', ['>=', column, min], ['<=', column, max]];
-      layerGroup.setFilterForLayer(layerID, expression);
+
+      layerGroup.layerIds.forEach((id) => {
+        layerGroup.setFilterForLayer(id, expression);
+      });
     },
   },
 });

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -103,7 +103,6 @@
     >
       <LayerControlTimeline
         @layerGroup={{this.layerGroups.zoning-map-amendments}}
-        @layerID="zma-fill"
         @column="effective_epoch"
       />
     </container.layer-group-toggle>

--- a/tests/integration/components/layer-control-timeline-test.js
+++ b/tests/integration/components/layer-control-timeline-test.js
@@ -22,7 +22,6 @@ module('Integration | Component | layer control timeline', function(hooks) {
       {{layer-control-timeline
         start=(array 1032370151000 1092370199000)
         layerGroup=layer
-        layerID='zma-fill'
         column='effective_epoch'
       }}`);
 
@@ -38,7 +37,6 @@ module('Integration | Component | layer control timeline', function(hooks) {
       {{layer-control-timeline
         start=(array 1032370151000 1092370199000)
         layerGroup=layer
-        layerID='zma-fill'
         column='effective_epoch'
       }}`);
 


### PR DESCRIPTION
This PR does two things:

- It increases the date range of the Zoning Map Amendment slide to include ZMAs from 1977 or later.
- It fixes a bug where this slider would only filter out the layer's fill features, but not its borders. It does this but now applying the same filter on all layers within the given layer-group.
