### PR TITLE
965: add inwood disclaimer on lot, special purpose, and zoning map am…

### DIFF
--- a/app/adapters/lot.js
+++ b/app/adapters/lot.js
@@ -19,6 +19,7 @@ const LotColumnsSQL = [
   'lotarea',
   'lotdepth',
   'lotfront',
+  'notes',
   'numbldgs',
   'numfloors',
   'ownername',
@@ -47,7 +48,7 @@ const LotColumnsSQL = [
 ];
 
 export const cartoQueryTemplate = function(id) {
-  return `SELECT ${LotColumnsSQL.join(',')}, 
+  return `SELECT ${LotColumnsSQL.join(',')},
     st_x(st_centroid(the_geom)) as lon, st_y(st_centroid(the_geom)) as lat,
     the_geom, bbl AS id FROM mappluto WHERE bbl=${id}`;
 };

--- a/app/models/map-features/lot.js
+++ b/app/models/map-features/lot.js
@@ -353,6 +353,8 @@ export default class LotFragment extends MF.Fragment {
 
   @attr('number') lotfront;
 
+  @attr('number') notes;
+
   @attr('number') numbldgs;
 
   @attr('number') numfloors;

--- a/app/templates/components/layer-record-views/special-purpose-district.hbs
+++ b/app/templates/components/layer-record-views/special-purpose-district.hbs
@@ -11,6 +11,11 @@
 <p>
   Since 1969, the City Planning Commission has designated special zoning districts in response to areas of the City with unique characteristics. Each special district stipulates zoning requirements and incentives tailored to specific conditions that may not lend themselves to generalized zoning and standard development.
 </p>
+{{#if (eq this.model.sdname 'Special Inwood District')}}
+  <div class="callout secondary">
+    <p>{{fa-icon 'exclamation-triangle' class='orange-muted'}} Note: All zoning regulations pertaining to the Special Inwood District Rezoning, which amended the Zoning Resolution (N 180205A ZRM) and Zoning Map (C 180204A ZMM), and which have been in effect since 8/8/18, are no longer in effect as of 12/19/19 per court order. For the applicable zoning designations currently in effect, please see zoning maps <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map1b.pdf" target="_blank">1b</a>, <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map1d.pdf" target="_blank">1d</a>, <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map3a.pdf" target="_blank">3a</a>, and <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map3c.pdf" target="_blank">3c</a>.</p>
+  </div>
+{{/if}}
 <p>
   <a href="{{this.model.readMoreLink}}" target="_blank">
     {{fa-icon "external-link-alt"}}

--- a/app/templates/components/layer-record-views/tax-lot.hbs
+++ b/app/templates/components/layer-record-views/tax-lot.hbs
@@ -210,6 +210,11 @@
       </ul>
     </div>
   </div>
+  {{#if (eq this.model.notes 1)}}
+    <div class="callout secondary">
+      <p>{{fa-icon 'exclamation-triangle' class='orange-muted'}} Note: This lot is within the Inwood Rezoning area. All zoning regulations pertaining to the Special Inwood District Rezoning, which amended the Zoning Resolution (N 180205A ZRM) and Zoning Map (C 180204A ZMM), and which have been in effect since 8/8/18, are no longer in effect as of 12/19/19 per court order. For the applicable zoning designations currently in effect, please see zoning maps <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map1b.pdf" target="_blank">1b</a>, <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map1d.pdf" target="_blank">1d</a>, <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map3a.pdf" target="_blank">3a</a>, and <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map3c.pdf" target="_blank">3c</a>.</p>
+    </div>
+  {{/if}}
 </section>
 <hr class="hide-for-print" />
 <section class="lot-details">

--- a/app/templates/components/layer-record-views/zoning-map-amendment.hbs
+++ b/app/templates/components/layer-record-views/zoning-map-amendment.hbs
@@ -53,4 +53,10 @@
     </a>
   </span>
 </div>
+<br>
+{{#if (eq this.model.project_na 'Inwood Rezoning')}}
+  <div class="callout secondary">
+    <p>{{fa-icon 'exclamation-triangle' class='orange-muted'}} Note: All zoning regulations pertaining to the Special Inwood District Rezoning, which amended the Zoning Resolution (N 180205A ZRM) and Zoning Map (C 180204A ZMM), and which have been in effect since 8/8/18, are no longer in effect as of 12/19/19 per court order. For the applicable zoning designations currently in effect, please see zoning maps <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map1b.pdf" target="_blank">1b</a>, <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map1d.pdf" target="_blank">1d</a>, <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map3a.pdf" target="_blank">3a</a>, and <a href="https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map3c.pdf" target="_blank">3c</a>.</p>
+  </div>
+{{/if}}
 {{yield}}


### PR DESCRIPTION
Adds the Inwood rezoning disclaimer on lot, special purpose, and zoning map amendment profiles.

For the tax lot profiles, the display of the disclaimer is dependent on a new field being added to mappluto called `notes` which will contain number codes. The number for the Inwood rezoning lawsuit contention will be `1` stored as a numeric. To test these code changes, I added a `notes` column to the table on Carto and set notes=1 for two different BBLs: 1022250010, 1022380023. 

EDM will soon provide updated mappluto data with all the appropriate lots tagged with 1 in the notes field. We shouldn't merge this work into master until we have that updated data.

Closes #965

**Screenshots:**

**Tax Lot**
![image](https://user-images.githubusercontent.com/13967925/71753450-a349b700-2e50-11ea-83f3-e4cd2c104c4d.png)

**Special Purpose District**
![image](https://user-images.githubusercontent.com/13967925/71753469-b5c3f080-2e50-11ea-9bba-5a939ff14125.png)

**Zoning Map Amendment** 
![image](https://user-images.githubusercontent.com/13967925/71753497-cb391a80-2e50-11ea-8622-c33a3e4ca9af.png)
