### PR TITLE
962: only show cyclomedia button, not embed

### DIFF
--- a/app/templates/components/road-view.hbs
+++ b/app/templates/components/road-view.hbs
@@ -1,18 +1,9 @@
 <div class="cyclomedia hide-for-print">
-  {{#if (and this.inView (media "desktop"))}}
-    <iframe
-      src={{this.url}}
-      class="cyclomedia"
-      allowfullscreen=""
-    ></iframe>
-  {{else}}
-    <a
-      class="button gray large reset-map-button hide-for-print"
-      href={{this.url}}
-      target="_blank"
-    >
-      {{fa-icon "external-link-alt"}} View Cyclomedia
-    </a>
-  {{/if}}
+  <a
+    class="button gray large reset-map-button hide-for-print"
+    href={{this.url}}
+    target="_blank"
+  >
+    {{fa-icon "external-link-alt"}} Cyclomedia Street View
+  </a>
 </div>
-<IsInViewport @inView={{this.inView}} />


### PR DESCRIPTION
Closes #962. Gets rid of conditional logic for providing cyclomedia access as an embedded widget vs. a button that opens in a new tab. Now we only provide the button.