### PR TITLE
Excludes the Open Graph tag preview image from asset fingerprinting

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -18,7 +18,7 @@
     <!-- Facebook / Open Graph tags -->
     <meta property="og:title" content="NYC Planning ZoLa" />
     <meta property="og:description" content="New York City's Zoning & Land Use Map" />
-    <meta property="og:image" content="https://zola.planning.nyc.gov/img/screenshot-1200x620.png" />
+    <meta property="og:image" content="https://zola.planning.nyc.gov/img/screenshot-1200x628.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="628" />
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -47,6 +47,9 @@ module.exports = (defaults) => {
         concat: false,
       },
     },
+    fingerprint: {
+      exclude: ['img/screenshot-1200x628.png'],
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
Assets get fingerprinted with MD5 hash at build time. This means the images will be broken if they are not correctly adjusted.

Closes #922 