### PR TITLE
298: Limit max pan and zoom out on map

### DIFF
--- a/app/services/main-map.js
+++ b/app/services/main-map.js
@@ -6,6 +6,8 @@ const DEFAULT_ZOOM = 9.72;
 const DEFAULT_LNG = 40.7125;
 const DEFAULT_LAT = -73.733;
 const DEFAULT_LAT_OFFSET = -0.1692;
+const MIN_ZOOM = 9.5;
+const MAX_BOUNDS = [[-74.5, 40.25], [-73, 41]];
 
 export default class MainMapService extends Service {
   mapInstance = null;
@@ -24,6 +26,10 @@ export default class MainMapService extends Service {
   routeIntentIsNested = false;
 
   zoom = DEFAULT_ZOOM;
+
+  minZoom = MIN_ZOOM;
+
+  maxBounds = MAX_BOUNDS;
 
   knownHashIntent = '';
 

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -7,6 +7,8 @@
     zoom=this.mainMap.zoom
     hash=true
     center=this.mainMap.center
+    minZoom=this.mainMap.minZoom
+    maxBounds=this.mainMap.maxBounds
   }}
   @mapLoaded={{action "handleMapLoad"}} as |map|
 >


### PR DESCRIPTION
This PR limits the max pan and zoom out to the immediate areas surrounding NYC. Closes #298.

Leaves some space to the east to accommodate the side content panel covering part of the map.

A: Max zoom out, most southwest corner:
<img width="830" alt="Screen Shot 2020-03-10 at 5 29 52 PM" src="https://user-images.githubusercontent.com/34144740/76370668-de56e380-62f4-11ea-9a3e-d2c65a7dc606.png">

B: Max zoom out, most northeast corner,
- With content panel open:
<img width="1393" alt="Screen Shot 2020-03-10 at 5 33 03 PM" src="https://user-images.githubusercontent.com/34144740/76370796-3aba0300-62f5-11ea-90a7-498b02745574.png">

- With content panel closed:
<img width="1392" alt="Screen Shot 2020-03-10 at 5 30 13 PM" src="https://user-images.githubusercontent.com/34144740/76370754-1e1dcb00-62f5-11ea-8304-9ff6110a915c.png">

Feel free to request any edits!