### PR TITLE
Remove deprecated phone number

### DIFF
--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -28,7 +28,7 @@
       target="_blank"
     >
       <strong>
-        Zoning Information Inquiry Form</strong></a> and a zoning specialist will get back to you within two business days (not including legal holidays).".
+        Zoning Information Inquiry Form</strong></a>, and a zoning specialist will get back to you within two business days (not including legal holidays).
   </p>
   <h3 class="header-medium small-margin-bottom">
     Application Feedback

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -28,7 +28,7 @@
       target="_blank"
     >
       <strong>
-        Zoning Information Inquiry Form</strong></a>.
+        Zoning Information Inquiry Form</strong></a> and a zoning specialist will get back to you within two business days (not including legal holidays).".
   </p>
   <h3 class="header-medium small-margin-bottom">
     Application Feedback

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -22,13 +22,7 @@
       target="_blank"
     >
     <strong>Zoning Help Desk FAQ</strong></a>.
-    If your question isn't answered there, call
-    <a href="tel:212-720-3291">
-      <strong>
-        212-720-3291
-      </strong>
-    </a>
-    during business hours (8:30AM–5:30PM, Monday–Friday, closed on legal holidays). Leave a detailed message with your block and lot information, and a zoning specialist will get back to you within two business days. Or fill out the
+    If your question is not answered there, please fill out the
     <a
       href="https://www1.nyc.gov/site/planning/zoning/zoning-inquiry.page"
       target="_blank"


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR addresses issue #1005 by removing the deprecated Zoning Help Desk phone line from the "Zoning Questions" section.

Changes Proposed:
- changes text to remove phone number and send users to the Zoning Information Inquiry form instead.

Closes #1005 
