### PR TITLE
Fixes pluto-driven bbl data

### DIFF
--- a/app/adapters/lot.js
+++ b/app/adapters/lot.js
@@ -50,7 +50,7 @@ const LotColumnsSQL = [
 export const cartoQueryTemplate = function(id) {
   return `SELECT ${LotColumnsSQL.join(',')},
     st_x(st_centroid(the_geom)) as lon, st_y(st_centroid(the_geom)) as lat,
-    the_geom, bbl AS id FROM mappluto WHERE bbl=${id}`;
+    the_geom, bbl AS id FROM dcp_mappluto WHERE bbl=${id}`;
 };
 
 export default CartoGeojsonFeatureAdapter.extend({


### PR DESCRIPTION
Updating the table slug to point to dcp_mappluto, the table in Carto that is synched via /edm-data-operations.

Addresses [AB#3737](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3737)