### PR TITLE
Swap visual hierarchy bt address and landmark in tax-lot view

### DIFF
--- a/app/styles/base/_typography.scss
+++ b/app/styles/base/_typography.scss
@@ -6,12 +6,12 @@
   @extend h3;
   margin-bottom: rem-calc(10);
 
-  .landmark {
+  .address {
     display: block;
     margin-bottom: 0;
   }
 
-  .landmark + .address {
+  .address + .landmark {
     display: block;
     @extend h4;
     margin-bottom: 0;

--- a/app/templates/components/layer-record-views/tax-lot.hbs
+++ b/app/templates/components/layer-record-views/tax-lot.hbs
@@ -11,14 +11,14 @@
   </span>
 </label>
 <h1 class="content-header">
+  <span class="address">
+    {{this.model.address}}, {{this.model.zipcode}}
+  </span>
   {{#if this.model.landmark}}
     <span class="landmark">
       {{this.model.landmark}}
     </span>
   {{/if}}
-  <span class="address">
-    {{this.model.address}}, {{this.model.zipcode}}
-  </span>
 </h1>
 <p class="text-small dark-gray">
   {{this.model.boroname}}&nbsp;(Borough {{this.model.borocode}})


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR closes #926. 

Changes Proposed:
Prefers the tax lot address placed at the top of the lot view.
