### PR TITLE
2844 Allow toggling individual flood subcategories

### DIFF
--- a/app/components/layer-palette.js
+++ b/app/components/layer-palette.js
@@ -7,33 +7,6 @@ import config from 'labs-zola/config/environment';
 
 const { zoningDistrictOptionSets, commercialOverlaysOptionSets } = config;
 
-const firmOverlaysOptionSets = [
-  {
-    name: 'V',
-    checked: true,
-    codes: ['V'],
-    style: {
-      color: '#0084a8',
-    },
-  },
-  {
-    name: 'A',
-    checked: true,
-    codes: ['A'],
-    style: {
-      color: '#00a9e6',
-    },
-  },
-  {
-    name: 'Shaded X',
-    checked: true,
-    codes: ['Shaded X'],
-    style: {
-      color: '#00ffc3',
-    },
-  },
-];
-
 @classNames('layer-palette')
 export default class LayerPaletteComponent extends Component {
   @service
@@ -62,10 +35,59 @@ export default class LayerPaletteComponent extends Component {
 
   commercialOverlaysOptionSets = commercialOverlaysOptionSets;
 
+  firmOverlaysOptionSets = [
+    {
+      name: 'V',
+      checked: true,
+      codes: ['V'],
+      style: {
+        color: '#0084a8',
+      },
+    },
+    {
+      name: 'A',
+      checked: true,
+      codes: ['A'],
+      style: {
+        color: '#00a9e6',
+      },
+    },
+    {
+      name: 'Shaded X',
+      checked: true,
+      codes: ['Shaded X'],
+      style: {
+        color: '#00ffc3',
+      },
+    },
+  ];
 
-  firmOverlaysOptionSets = firmOverlaysOptionSets
-
-  pfirmOverlaysOptionSets = firmOverlaysOptionSets;
+  pfirmOverlaysOptionSets = [
+    {
+      name: 'V',
+      checked: true,
+      codes: ['p_V'],
+      style: {
+        color: '#0084a8',
+      },
+    },
+    {
+      name: 'A',
+      checked: true,
+      codes: ['p_A'],
+      style: {
+        color: '#00a9e6',
+      },
+    },
+    {
+      name: 'Shaded X',
+      checked: true,
+      codes: ['p_Shaded X'],
+      style: {
+        color: '#00ffc3',
+      },
+    },
+  ];
 
   layerGroups;
 

--- a/app/components/layer-palette.js
+++ b/app/components/layer-palette.js
@@ -7,6 +7,33 @@ import config from 'labs-zola/config/environment';
 
 const { zoningDistrictOptionSets, commercialOverlaysOptionSets } = config;
 
+const firmOverlaysOptionSets = [
+  {
+    name: 'V',
+    checked: true,
+    codes: ['V'],
+    style: {
+      color: '#0084a8',
+    },
+  },
+  {
+    name: 'A',
+    checked: true,
+    codes: ['A'],
+    style: {
+      color: '#00a9e6',
+    },
+  },
+  {
+    name: 'Shaded X',
+    checked: true,
+    codes: ['Shaded X'],
+    style: {
+      color: '#00ffc3',
+    },
+  },
+];
+
 @classNames('layer-palette')
 export default class LayerPaletteComponent extends Component {
   @service
@@ -35,6 +62,11 @@ export default class LayerPaletteComponent extends Component {
 
   commercialOverlaysOptionSets = commercialOverlaysOptionSets;
 
+
+  firmOverlaysOptionSets = firmOverlaysOptionSets
+
+  pfirmOverlaysOptionSets = firmOverlaysOptionSets;
+
   layerGroups;
 
   closed = true;
@@ -45,7 +77,6 @@ export default class LayerPaletteComponent extends Component {
 
   handleLayerGroupChange = () => {};
 
-  // where should these go?
   @action
   setFilterForZoning() {
     const expression = [
@@ -62,7 +93,6 @@ export default class LayerPaletteComponent extends Component {
     }
   }
 
-  // where should these go?
   @action
   setFilterForOverlays() {
     const expression = [
@@ -76,6 +106,8 @@ export default class LayerPaletteComponent extends Component {
       next(() => {
         this.layerGroups['commercial-overlays'].setFilterForLayer('co', expression);
         this.layerGroups['commercial-overlays'].setFilterForLayer('co_labels', expression);
+        this.layerGroups['floodplain-efirm2007'].setFilterForLayer('effective-flood-insurance-rate-2007', expression);
+        this.layerGroups['floodplain-pfirm2015'].setFilterForLayer('preliminary-flood-insurance-rate', expression);
       });
     }
   }

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -192,18 +192,34 @@
       @layerGroup={{this.layerGroups.floodplain-efirm2007}}
       @activeTooltip={{zoom-dependent-label this.layerGroups.floodplain-efirm2007 this.zoomWarningLabel this.mainMap.zoom}}
     >
-      <LabsUi::LegendItems
-        @items={{this.layerGroups.floodplain-efirm2007.legend.items}}
-      />
+      <ul class="layer-menu-item--group-checkboxes">
+        {{#each this.firmOverlaysOptionSets as |optionSet|}}
+          <li>
+            <GroupedCheckboxes
+              @group={{optionSet}}
+              @selected={{this.selectedOverlays}}
+              @selectionChanged={{action this.setFilterForOverlays}}
+            />
+          </li>
+        {{/each}}
+      </ul>
     </container.layer-group-toggle>
     <container.layer-group-toggle
       data-test-toggle-floodplain-pfirm2015
       @layerGroup={{this.layerGroups.floodplain-pfirm2015}}
       @activeTooltip={{zoom-dependent-label this.layerGroups.floodplain-pfirm2015 this.zoomWarningLabel this.mainMap.zoom}}
     >
-      <LabsUi::LegendItems
-        @items={{this.layerGroups.floodplain-pfirm2015.legend.items}}
-      />
+      <ul class="layer-menu-item--group-checkboxes">
+        {{#each this.pfirmOverlaysOptionSets as |optionSet|}}
+          <li>
+            <GroupedCheckboxes
+              @group={{optionSet}}
+              @selected={{this.selectedOverlays}}
+              @selectionChanged={{action this.setFilterForOverlays}}
+            />
+          </li>
+        {{/each}}
+      </ul>
     </container.layer-group-toggle>
     <container.layer-group-toggle
       data-test-toggle-e-designations


### PR DESCRIPTION
Accommodates the extra request to enable toggling individual flood subcategories. 

Builds off existing pattern used for Commercial Districts and Zoning Districts.

Unfortunately this existing pattern is really poorly designed. It depends on those layer sources to have an `overlay` attribute, and the `layer-palette` component code will apply a global array of filters on `overlay` to every layer. So it depends on the `overlay` attribute values to be unique across layers.

In the corresponding [layers-api PR](https://github.com/NYCPlanning/labs-layers-api/pull/259), the flood layer sources now have an `overlay` virtual attribute that is almost a duplicate of `fld_zone`. The pfirm source makes the A, V, Shaded X values unique by prepending `p_`

**Also** moves away from previous pattern of holding overlay configurations in `environment/config.js`.  That was a bad and unnecessary design, because it required restarting the server every time those configs were changed.

Fixes [AB#2844](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2844) 

pairs with https://github.com/NYCPlanning/labs-layers-api/pull/259

![image](https://user-images.githubusercontent.com/3311663/141537733-aa1d7792-c915-456d-a0c1-95924d831f55.png)