### PR TITLE
2844 Toggle flood VAX sublayers by default, refactor floodplain filtering

### DIFF
--- a/app/components/layer-palette.js
+++ b/app/components/layer-palette.js
@@ -5,7 +5,12 @@ import { classNames } from '@ember-decorators/component';
 import { next } from '@ember/runloop';
 import config from 'labs-zola/config/environment';
 
-const { zoningDistrictOptionSets, commercialOverlaysOptionSets } = config;
+const {
+  zoningDistrictOptionSets,
+  commercialOverlaysOptionSets,
+  floodplainEfirm2007OptionSets,
+  floodplainPfirm2015OptionSets,
+} = config;
 
 @classNames('layer-palette')
 export default class LayerPaletteComponent extends Component {
@@ -20,6 +25,8 @@ export default class LayerPaletteComponent extends Component {
 
     this.setFilterForZoning();
     this.setFilterForOverlays();
+    this.setFilterForFirm();
+    this.setFilterForPfirm();
   }
 
   @service
@@ -31,63 +38,17 @@ export default class LayerPaletteComponent extends Component {
 
   selectedOverlays = [];
 
+  selectedFirm = [];
+
+  selectedPfirm = [];
+
   zoningDistrictOptionSets = zoningDistrictOptionSets;
 
   commercialOverlaysOptionSets = commercialOverlaysOptionSets;
 
-  firmOverlaysOptionSets = [
-    {
-      name: 'V',
-      checked: true,
-      codes: ['V'],
-      style: {
-        color: '#0084a8',
-      },
-    },
-    {
-      name: 'A',
-      checked: true,
-      codes: ['A'],
-      style: {
-        color: '#00a9e6',
-      },
-    },
-    {
-      name: 'Shaded X',
-      checked: true,
-      codes: ['Shaded X'],
-      style: {
-        color: '#00ffc3',
-      },
-    },
-  ];
+  firmOptionSets = floodplainEfirm2007OptionSets;
 
-  pfirmOverlaysOptionSets = [
-    {
-      name: 'V',
-      checked: true,
-      codes: ['p_V'],
-      style: {
-        color: '#0084a8',
-      },
-    },
-    {
-      name: 'A',
-      checked: true,
-      codes: ['p_A'],
-      style: {
-        color: '#00a9e6',
-      },
-    },
-    {
-      name: 'Shaded X',
-      checked: true,
-      codes: ['p_Shaded X'],
-      style: {
-        color: '#00ffc3',
-      },
-    },
-  ];
+  pfirmOptionSets = floodplainPfirm2015OptionSets;
 
   layerGroups;
 
@@ -129,6 +90,38 @@ export default class LayerPaletteComponent extends Component {
         this.layerGroups['commercial-overlays'].setFilterForLayer('co', expression);
         this.layerGroups['commercial-overlays'].setFilterForLayer('co_labels', expression);
         this.layerGroups['floodplain-efirm2007'].setFilterForLayer('effective-flood-insurance-rate-2007', expression);
+        this.layerGroups['floodplain-pfirm2015'].setFilterForLayer('preliminary-flood-insurance-rate', expression);
+      });
+    }
+  }
+
+  @action
+  setFilterForFirm() {
+    const expression = [
+      'any',
+      ...this.selectedFirm.map(value => ['==', 'fld_zone', value]),
+    ];
+
+    // if-guard to prevent the node-based fastboot server from running this
+    // mapbox-gl method which gets ignored in fastboot.
+    if (!this.fastboot.isFastBoot) {
+      next(() => {
+        this.layerGroups['floodplain-efirm2007'].setFilterForLayer('effective-flood-insurance-rate-2007', expression);
+      });
+    }
+  }
+
+  @action
+  setFilterForPfirm() {
+    const expression = [
+      'any',
+      ...this.selectedPfirm.map(value => ['==', 'fld_zone', value]),
+    ];
+
+    // if-guard to prevent the node-based fastboot server from running this
+    // mapbox-gl method which gets ignored in fastboot.
+    if (!this.fastboot.isFastBoot) {
+      next(() => {
         this.layerGroups['floodplain-pfirm2015'].setFilterForLayer('preliminary-flood-insurance-rate', expression);
       });
     }

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -9,6 +9,8 @@ const {
   defaultLayerGroupState,
   zoningDistrictOptionSets,
   commercialOverlaysOptionSets,
+  floodplainEfirm2007OptionSets,
+  floodplainPfirm2015OptionSets,
 } = config;
 
 const defaultLayerGroups = defaultLayerGroupState
@@ -26,6 +28,16 @@ const defaultSelectedZoningDistricts = zoningDistrictOptionSets
   .reduce((acc, curr) => acc.concat(curr))
   .sort();
 
+const defaultSelectedFirmOptionSets = floodplainEfirm2007OptionSets
+  .map(({ codes }) => codes)
+  .reduce((acc, curr) => acc.concat(curr))
+  .sort();
+
+const defaultSelectedPfirmOptionSets = floodplainPfirm2015OptionSets
+  .map(({ codes }) => codes)
+  .reduce((acc, curr) => acc.concat(curr))
+  .sort();
+
 // define new query params here:
 export const mapQueryParams = new QueryParams(
   assign(
@@ -39,8 +51,17 @@ export const mapQueryParams = new QueryParams(
       selectedZoning: {
         defaultValue: defaultSelectedZoningDistricts,
       },
+
       selectedOverlays: {
         defaultValue: defaultSelectedOverlays,
+      },
+
+      selectedFirm: {
+        defaultValue: defaultSelectedFirmOptionSets,
+      },
+
+      selectedPfirm: {
+        defaultValue: defaultSelectedPfirmOptionSets,
       },
 
       'aerial-year': {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -28,6 +28,8 @@
         <LayerPalette
           @selectedZoning={{this.selectedZoning}}
           @selectedOverlays={{this.selectedOverlays}}
+          @selectedFirm={{this.selectedFirm}}
+          @selectedPfirm={{this.selectedPfirm}}
           @layerGroups={{model.layerGroupsObject}}
           @isDefault={{isDefault}}
           @resetQueryParams={{action this.setModelsToDefault}}

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -193,12 +193,12 @@
       @activeTooltip={{zoom-dependent-label this.layerGroups.floodplain-efirm2007 this.zoomWarningLabel this.mainMap.zoom}}
     >
       <ul class="layer-menu-item--group-checkboxes">
-        {{#each this.firmOverlaysOptionSets as |optionSet|}}
+        {{#each this.firmOptionSets as |optionSet|}}
           <li>
             <GroupedCheckboxes
               @group={{optionSet}}
-              @selected={{this.selectedOverlays}}
-              @selectionChanged={{action this.setFilterForOverlays}}
+              @selected={{this.selectedFirm}}
+              @selectionChanged={{action this.setFilterForFirm}}
             />
           </li>
         {{/each}}
@@ -210,12 +210,12 @@
       @activeTooltip={{zoom-dependent-label this.layerGroups.floodplain-pfirm2015 this.zoomWarningLabel this.mainMap.zoom}}
     >
       <ul class="layer-menu-item--group-checkboxes">
-        {{#each this.pfirmOverlaysOptionSets as |optionSet|}}
+        {{#each this.pfirmOptionSets as |optionSet|}}
           <li>
             <GroupedCheckboxes
               @group={{optionSet}}
-              @selected={{this.selectedOverlays}}
-              @selectionChanged={{action this.setFilterForOverlays}}
+              @selected={{this.selectedPfirm}}
+              @selectionChanged={{action this.setFilterForPfirm}}
             />
           </li>
         {{/each}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -197,6 +197,60 @@ module.exports = function(environment) {
       },
     ],
 
+    floodplainEfirm2007OptionSets: [
+      {
+        name: 'V',
+        checked: true,
+        codes: ['V'],
+        style: {
+          color: '#0084a8',
+        },
+      },
+      {
+        name: 'A',
+        checked: true,
+        codes: ['A'],
+        style: {
+          color: '#00a9e6',
+        },
+      },
+      {
+        name: 'Shaded X',
+        checked: true,
+        codes: ['Shaded X'],
+        style: {
+          color: '#00ffc3',
+        },
+      },
+    ],
+
+    floodplainPfirm2015OptionSets: [
+      {
+        name: 'V',
+        checked: true,
+        codes: ['V'],
+        style: {
+          color: '#0084a8',
+        },
+      },
+      {
+        name: 'A',
+        checked: true,
+        codes: ['A'],
+        style: {
+          color: '#00a9e6',
+        },
+      },
+      {
+        name: 'Shaded X',
+        checked: true,
+        codes: ['Shaded X'],
+        style: {
+          color: '#00ffc3',
+        },
+      },
+    ],
+
     'mapbox-gl': {
       accessToken: 'pk.eyJ1IjoiY3dob25nbnljIiwiYSI6ImNpczF1MXdrdjA4MXcycXA4ZGtyN2x5YXIifQ.3HGyME8tBs6BnljzUVIt4Q',
     },


### PR DESCRIPTION
Fixes [AB#2844](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2844)

Munged two things in this PR (Dont at me :3):
 1. Realized I was wrong in my last PR about the global filter on the `overlay` property. Instead I can create a different filter action for firm and pfirm, aside from commercial overlays. The new filter actions will filter on `fld_zone` specifically. Having separate actions also means I don't need the `p_` prefix in front of pfirm codes. 
 Consequently I have a sibling PR in layers api to remove the virtual `overlay` attribute I added to the layer groups for fema_firm and fema_pfirm: https://github.com/NYCPlanning/labs-layers-api/pull/260
 
   2. Figured out how to have subtoggles checked by default when the parent toggle is activated (while keeping the parent toggle off by default on App load).  Required initialization steps in multiple inconspicuous places 😫 
   
![image](https://user-images.githubusercontent.com/3311663/142283133-168c83a0-9e1e-4461-a45e-82728f389fdf.png)
