### PR TITLE
Use latest special purpose districts table

### DIFF
--- a/app/models/map-features/lot.js
+++ b/app/models/map-features/lot.js
@@ -499,7 +499,7 @@ export default class LotFragment extends MF.Fragment {
       const spdist2 = this.get('spdist2');
       const spdist3 = this.get('spdist3');
 
-      return carto.SQL(specialPurposeDistrictsSQL('special_purpose_districts', spdist1, spdist2, spdist3))
+      return carto.SQL(specialPurposeDistrictsSQL('dcp_special_purpose_districts', spdist1, spdist2, spdist3))
         .then(response => response.map(
           (item) => {
             const [, [anchorName, boroName]] = specialDistrictCrosswalk

--- a/app/templates/components/layer-record-views/tax-lot.hbs
+++ b/app/templates/components/layer-record-views/tax-lot.hbs
@@ -97,6 +97,7 @@
     {{#each
       (await this.model.parentSpecialPurposeDistricts) as |specialDistrict|
     }}
+    {{log specialDistrict}}
       <li
         data-test-special-district
       >


### PR DESCRIPTION
Fixes [AB#6068](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/6068)

EDM ensures that the latest data is always available in the `dcp_special_purpose_districts` table. This PR updates the call to include it.
