### PR TITLE
8269 'Special Purpose Subdistricts' data does not show

### DIFF
--- a/app/adapters/special-purpose-subdistrict.js
+++ b/app/adapters/special-purpose-subdistrict.js
@@ -8,8 +8,7 @@ const SQL = function(id) {
       the_geom,
       spname,
       splbl,
-      subdist,
-      subsub
+      subdist
     FROM dcp_special_purpose_subdistricts
     WHERE cartodb_id='${id}'`;
 };


### PR DESCRIPTION
This removes an variable "subsub" that does not exist in the current version of the subdistricts table.  Previous version of the table did contain the column, but all values were NULL.

Closes #AB8269
