### PR TITLE
7514 Zola Issue: Special Districts (2) property search results not displaying info for newly added districts

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -142,6 +142,7 @@ module.exports = function(environment) {
       ['Special St. George District', ['SG', 'staten-island']],
       ['Special South Richmond Development District', ['SRD', 'staten-island']],
       ['Special Stapleton Waterfront District', ['SW', 'staten-island']],
+      ['Special Gowanus Mixed-Use District', ['G', 'brooklyn']],
     ],
 
     zoningDistrictOptionSets: [


### PR DESCRIPTION
This PR adds Gowanus to the environment file.  Bug also mentions Jerome Ave, which had been fixed in a previous update.

Closes #AB7514
