### PR TITLE
9441 'Print' event sent to Google Analytics on site load

### DIFF
--- a/app/services/print.js
+++ b/app/services/print.js
@@ -32,11 +32,13 @@ export default class PrintService extends Service {
   @computed('printViewHiddenAreas', 'enabled', 'printViewPaperSize', 'printViewOrientation', 'printViewHiddenAreas')
   get printViewClasses() {
     // GA
-    this.get('metrics').trackEvent('GoogleAnalytics', {
-      eventCategory: 'Print',
-      eventAction: `${this.enabled ? 'Enabled print view' : ''}`,
-      eventLabel: 'export',
-    });
+    if (this.enabled) {
+      this.get('metrics').trackEvent('GoogleAnalytics', {
+        eventCategory: 'Print',
+        eventAction: 'Enabled print view',
+        eventLabel: 'export',
+      });
+    }
 
     const orientation = this.printViewOrientation;
     const size = this.printViewPaperSize;


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

Implements logic to fire event tag only when print view is enabled, not every time site loads.

Closes #AB9441
