### PR TITLE
Switch to geosearch v2 helper and package.json tweaks

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -266,9 +266,8 @@ module.exports = function(environment) {
     },
 
     'labs-search': {
-      host: 'https://search-api-production.herokuapp.com',
       helpers: [
-        'geosearch',
+        'geosearch-v2',
         'bbl',
         'neighborhood',
         'zoning-district',
@@ -355,6 +354,8 @@ module.exports = function(environment) {
     ENV['ember-cli-mirage'] = {
       enabled: false,
     };
+
+    ENV['labs-search'].host = 'https://search-api-staging.herokuapp.com';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -374,19 +375,16 @@ module.exports = function(environment) {
     ENV.APP.autoboot = false;
 
     ENV['labs-search'] = {
-      host: 'https://search-api.planninglabs.nyc',
-      helpers: [
-        'geosearch',
-        'bbl',
-        'neighborhood',
-        'zoning-district',
-        'zoning-map-amendment',
-        'special-purpose-district',
-        'commercial-overlay',
-      ],
+      host: 'https://search-api-staging.herokuapp.com',
     };
 
     ENV.host = '';
+  }
+
+  if (environment === 'production') {
+    ENV['labs-search'] = {
+      host: 'https://search-api-production.herokuapp.com',
+    };
   }
 
   return ENV;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "ember build",
     "lint": "./node_modules/.bin/eslint ./*.js app config lib server tests",
     "lint:hbs": "ember-template-lint .",
-    "start": "ember serve",
+    "start": "ember serve -dev",
     "test": "ember test",
     "prepare": "husky install"
   },


### PR DESCRIPTION
## Summary

This PR updates Zola to use the new `geosearch-v2` Search API helper. I also tweaked package.json and environment.js to make it easier to point at staging 
