### PR TITLE
10276 Zola GA4 Implementation (Revised)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -18,3 +18,6 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# eslint
+/.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
     'no-param-reassign': 0,
     'ember/avoid-leaking-state-in-ember-objects': 0,
     'ember-best-practices/require-dependent-keys': 0,
+    'no-undef': 0,
   },
   overrides: [
     // node files

--- a/app/components/bookmarks/bookmark-button.js
+++ b/app/components/bookmarks/bookmark-button.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
-import gtag from 'labs-zola/utils/gtag';
 
 export default class BookmarkButton extends Component {
   bookmarkableModel = null;

--- a/app/components/bookmarks/bookmark-button.js
+++ b/app/components/bookmarks/bookmark-button.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import gtag from 'labs-zola/utils/gtag';
 
 export default class BookmarkButton extends Component {
   bookmarkableModel = null;
@@ -24,6 +25,11 @@ export default class BookmarkButton extends Component {
     const resolvedBookmark = await bookmark;
 
     if (resolvedBookmark) {
+      gtag('event', 'delete_bookmark', {
+        event_category: 'Bookmark',
+        event_action: 'Deleted Bookmark',
+      });
+
       resolvedBookmark.deleteRecord();
       resolvedBookmark.save();
     } else {
@@ -33,6 +39,11 @@ export default class BookmarkButton extends Component {
 
   @action
   async createBookmark() {
+    gtag('event', 'bookmark', {
+      event_category: 'Bookmark',
+      event_action: 'Used Bookmark',
+    });
+
     // GA
     this.get('metrics').trackEvent('GoogleAnalytics', {
       eventCategory: 'Bookmark',

--- a/app/components/bookmarks/types/-default.js
+++ b/app/components/bookmarks/types/-default.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import gtag from 'labs-zola/utils/gtag';
 import layout from '../../../templates/components/bookmarks/types/-default';
 
 export default class DefaultBookmark extends Component {

--- a/app/components/bookmarks/types/-default.js
+++ b/app/components/bookmarks/types/-default.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import gtag from 'labs-zola/utils/gtag';
 import layout from '../../../templates/components/bookmarks/types/-default';
 
 export default class DefaultBookmark extends Component {
@@ -15,10 +16,20 @@ export default class DefaultBookmark extends Component {
   deleteBookmark(bookmark) {
     bookmark.deleteRecord();
     bookmark.save();
+
+    gtag('event', 'delete_bookmark', {
+      event_category: 'Bookmark',
+      event_action: 'Deleted Bookmark',
+    });
   }
 
   @action
   async captureBookmarkDownload(format) {
+    gtag('event', 'download_bookmark', {
+      event_category: 'Download',
+      event_action: `Downloaded Bookmark as ${format}`,
+    });
+
     // GA
     this.get('metrics').trackEvent('GoogleAnalytics', {
       eventCategory: 'Download',

--- a/app/components/is-in-viewport.js
+++ b/app/components/is-in-viewport.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import InViewportMixin from 'ember-in-viewport';
 import { inject as service } from '@ember/service';
+import gtag from 'labs-zola/utils/gtag';
 
 export default class IsInViewportComponent extends Component.extend(InViewportMixin) {
   inView;
@@ -9,6 +10,10 @@ export default class IsInViewportComponent extends Component.extend(InViewportMi
   metrics;
 
   didEnterViewport() {
+    gtag('event', 'road_view', {
+      event_category: 'Road View',
+      event_action: 'Scrolled to bottom of a side panel',
+    });
     // GA
     this.get('metrics').trackEvent('GoogleAnalytics', {
       eventCategory: 'Road View',

--- a/app/components/is-in-viewport.js
+++ b/app/components/is-in-viewport.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import InViewportMixin from 'ember-in-viewport';
 import { inject as service } from '@ember/service';
-import gtag from 'labs-zola/utils/gtag';
 
 export default class IsInViewportComponent extends Component.extend(InViewportMixin) {
   inView;

--- a/app/components/labs-ui/layer-group-toggle.js
+++ b/app/components/labs-ui/layer-group-toggle.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import gtag from 'labs-zola/utils/gtag';
 import layout from '../../templates/components/labs-ui/layer-group-toggle';
 
 export default class LayerGroupToggle extends Component {

--- a/app/components/labs-ui/layer-group-toggle.js
+++ b/app/components/labs-ui/layer-group-toggle.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import gtag from 'labs-zola/utils/gtag';
 import layout from '../../templates/components/labs-ui/layer-group-toggle';
 
 export default class LayerGroupToggle extends Component {
@@ -82,6 +83,11 @@ export default class LayerGroupToggle extends Component {
 
   @action
   async captureOutboundLink(label) {
+    gtag('event', 'external_link', {
+      event_category: 'Clicked Supporting Zoning Link',
+      event_action: `Clicked ${label} Link`,
+    });
+
     // GA
     this.get('metrics').trackEvent('GoogleAnalytics', {
       eventCategory: 'External Link',

--- a/app/components/layer-palette.js
+++ b/app/components/layer-palette.js
@@ -4,7 +4,6 @@ import { action } from '@ember/object';
 import { classNames } from '@ember-decorators/component';
 import { next } from '@ember/runloop';
 import config from 'labs-zola/config/environment';
-import gtag from 'labs-zola/utils/gtag';
 
 const {
   zoningDistrictOptionSets,

--- a/app/components/layer-palette.js
+++ b/app/components/layer-palette.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { classNames } from '@ember-decorators/component';
 import { next } from '@ember/runloop';
 import config from 'labs-zola/config/environment';
+import gtag from 'labs-zola/utils/gtag';
 
 const {
   zoningDistrictOptionSets,
@@ -141,6 +142,11 @@ export default class LayerPaletteComponent extends Component {
 
   @action
   handleLayerGroupToggle(layerGroup) {
+    gtag('event', 'toggle_layer', {
+      event_category: 'Layers',
+      event_action: `${layerGroup.visible ? 'Turned on' : 'Turned off'} ${layerGroup.legend.label}`,
+    });
+
     // GA
     this.get('metrics').trackEvent('GoogleAnalytics', {
       eventCategory: 'Layers',

--- a/app/components/layer-record-views/-base.js
+++ b/app/components/layer-record-views/-base.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import gtag from 'labs-zola/utils/gtag';
 
 export default class LayerRecordBase extends Component {
   @service
@@ -10,6 +11,10 @@ export default class LayerRecordBase extends Component {
 
   @action
   async captureOutboundLink(label) {
+    gtag('event', 'external_link', {
+      event_category: 'External Link',
+      event_action: `Clicked ${label} Link`,
+    });
     // GA
     this.get('metrics').trackEvent('GoogleAnalytics', {
       eventCategory: 'External Link',

--- a/app/components/layer-record-views/-base.js
+++ b/app/components/layer-record-views/-base.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import gtag from 'labs-zola/utils/gtag';
 
 export default class LayerRecordBase extends Component {
   @service

--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -6,7 +6,6 @@ import { computed, action } from '@ember/object';
 import { classNames } from '@ember-decorators/component';
 import { alias } from '@ember/object/computed';
 
-import gtag from 'labs-zola/utils/gtag';
 import bblDemux from '../utils/bbl-demux';
 import drawnFeatureLayers from '../layers/drawn-feature';
 import selectedLayers from '../layers/selected-lot';

--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -6,6 +6,7 @@ import { computed, action } from '@ember/object';
 import { classNames } from '@ember-decorators/component';
 import { alias } from '@ember/object/computed';
 
+import gtag from 'labs-zola/utils/gtag';
 import bblDemux from '../utils/bbl-demux';
 import drawnFeatureLayers from '../layers/drawn-feature';
 import selectedLayers from '../layers/selected-lot';
@@ -42,6 +43,9 @@ export default class MainMap extends Component {
   @service
   router;
 
+  @service('print')
+  printSvc;
+
   menuTo = 'layers-menu';
 
   loading = true;
@@ -55,6 +59,17 @@ export default class MainMap extends Component {
   drawnFeatureLayers = drawnFeatureLayers;
 
   highlightedLayerId = null;
+
+  widowResize() {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const resizeEvent = window.document.createEvent('UIEvents');
+        resizeEvent.initUIEvent('resize', true, false, window, 0);
+        window.dispatchEvent(resizeEvent);
+        resolve();
+      }, 300);
+    });
+  }
 
   @computed('layerGroupsObject')
   get mapConfig() {
@@ -254,5 +269,17 @@ export default class MainMap extends Component {
   @action
   handleLayerHighlight(e, Layer) {
     this.set('highlightedLayerId', Layer.get('id'));
+  }
+
+  @action
+  async enablePrintView() {
+    gtag('event', 'print', {
+      event_category: 'Print',
+      event_action: 'Enabled print view',
+    });
+
+    this.set('printSvc.enabled', true);
+
+    await this.widowResize();
   }
 }

--- a/app/components/map-measurement-tools.js
+++ b/app/components/map-measurement-tools.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import numeral from 'numeral';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import gtag from 'labs-zola/utils/gtag';
 import drawStyles from '../layers/draw-styles';
 
 export default class MapMeasurementToolsComponent extends Component {

--- a/app/components/map-measurement-tools.js
+++ b/app/components/map-measurement-tools.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import numeral from 'numeral';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import gtag from 'labs-zola/utils/gtag';
 import drawStyles from '../layers/draw-styles';
 
 export default class MapMeasurementToolsComponent extends Component {
@@ -32,6 +33,11 @@ export default class MapMeasurementToolsComponent extends Component {
 
   @action
   async startDraw(type) {
+    gtag('event', 'draw_tool', {
+      event_category: 'Measurement',
+      event_action: 'Used measurement tool',
+    });
+
     // GA
     this.get('metrics').trackEvent('GoogleAnalytics', {
       eventCategory: 'Measurement',

--- a/app/components/map-resource-search.js
+++ b/app/components/map-resource-search.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import gtag from 'labs-zola/utils/gtag';
 import bblDemux from '../utils/bbl-demux';
 
 export default class MapResourceSearchComponent extends Component {
@@ -18,6 +19,11 @@ export default class MapResourceSearchComponent extends Component {
     // if onSuccess from labs-bbl-lookup includes bbl, transition to lot route for that bbl
     // otherwise flyTo the block
     if (bbl) {
+      gtag('event', 'search', {
+        event_category: 'Search',
+        event_action: 'Used BBL Lookup',
+      });
+
       // GA
       this.get('metrics').trackEvent('GoogleAnalytics', {
         eventCategory: 'Search',
@@ -46,11 +52,19 @@ export default class MapResourceSearchComponent extends Component {
       // GA
       // address search maps to all-uppercase addresses whereas bbl lookups map to normal case addresses
       if (result.label.split(',')[0] === result.label.split(',')[0].toUpperCase()) {
+        gtag('event', 'search', {
+          event_category: 'Search',
+          event_action: 'Searched by Address',
+        });
         this.get('metrics').trackEvent('GoogleAnalytics', {
           eventCategory: 'Search',
           eventAction: 'Searched by Address',
         });
       } else {
+        gtag('event', 'search', {
+          event_category: 'Search',
+          event_action: 'Used BBL Lookup',
+        });
         this.get('metrics').trackEvent('GoogleAnalytics', {
           eventCategory: 'Search',
           eventAction: 'Used BBL Lookup',
@@ -68,6 +82,10 @@ export default class MapResourceSearchComponent extends Component {
     }
 
     if (type === 'zoning-district') {
+      gtag('event', 'search', {
+        event_category: 'Search',
+        event_action: 'Searched by Zoning District',
+      });
       // GA
       this.get('metrics').trackEvent('GoogleAnalytics', {
         eventCategory: 'Search',

--- a/app/components/map-resource-search.js
+++ b/app/components/map-resource-search.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import gtag from 'labs-zola/utils/gtag';
 import bblDemux from '../utils/bbl-demux';
 
 export default class MapResourceSearchComponent extends Component {

--- a/app/components/mapbox/fit-map-to-all-button.js
+++ b/app/components/mapbox/fit-map-to-all-button.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
-import gtag from 'labs-zola/utils/gtag';
 
 export default class MapboxFixMapToAllButton extends Component {
   // should be carto-geojson-model-like

--- a/app/components/mapbox/fit-map-to-all-button.js
+++ b/app/components/mapbox/fit-map-to-all-button.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import gtag from 'labs-zola/utils/gtag';
 
 export default class MapboxFixMapToAllButton extends Component {
   // should be carto-geojson-model-like
@@ -11,6 +12,10 @@ export default class MapboxFixMapToAllButton extends Component {
 
   @action
   fitBounds() {
+    gtag('event', 'fit_map', {
+      event_category: 'Fit Map to Districts',
+    });
+
     this.get('mainMap.setBounds').perform(this.model.bounds);
   }
 }

--- a/app/components/print-view-controls.js
+++ b/app/components/print-view-controls.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import gtag from 'labs-zola/utils/gtag';
 
 export default class PrintViewControls extends Component {
   classNames = ['print-view--controls', 'align-middle'];
@@ -24,6 +25,10 @@ export default class PrintViewControls extends Component {
 
   @action
   async disablePrintView() {
+    gtag('event', 'print', {
+      event_category: 'Print',
+      event_action: 'Disabled print view',
+    });
     // GA
     this.get('metrics').trackEvent('GoogleAnalytics', {
       eventCategory: 'Print',

--- a/app/components/print-view-controls.js
+++ b/app/components/print-view-controls.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import gtag from 'labs-zola/utils/gtag';
 
 export default class PrintViewControls extends Component {
   classNames = ['print-view--controls', 'align-middle'];

--- a/app/components/road-view.js
+++ b/app/components/road-view.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import InViewportMixin from 'ember-in-viewport';
 import { computed } from '@ember/object';
-import gtag from 'labs-zola/utils/gtag';
 
 export default class RoadView extends Component.extend(InViewportMixin) {
   lat;

--- a/app/components/road-view.js
+++ b/app/components/road-view.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import InViewportMixin from 'ember-in-viewport';
 import { computed } from '@ember/object';
+import gtag from 'labs-zola/utils/gtag';
 
 export default class RoadView extends Component.extend(InViewportMixin) {
   lat;
@@ -12,5 +13,12 @@ export default class RoadView extends Component.extend(InViewportMixin) {
   @computed('lon', 'lat')
   get url() {
     return `https://roadview.planninglabs.nyc/view/${this.lon}/${this.lat}`;
+  }
+
+  onClick() {
+    gtag('event', 'external_link', {
+      event_category: 'External Link',
+      event_action: 'Clicked Cyclomedia Street View Link',
+    });
   }
 }

--- a/app/index.html
+++ b/app/index.html
@@ -6,7 +6,18 @@
     <title>ZoLa | NYC&rsquo;s Zoning &amp; Land Use Map</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+   
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-CL1BGY7RZM"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
 
+      // gtag('config', 'G-CL1BGY7RZM', { 'debug_mode':true });
+      gtag('config', 'G-CL1BGY7RZM');
+    </script>
+ 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@nycplanning" />

--- a/app/services/print.js
+++ b/app/services/print.js
@@ -31,15 +31,6 @@ export default class PrintService extends Service {
 
   @computed('printViewHiddenAreas', 'enabled', 'printViewPaperSize', 'printViewOrientation', 'printViewHiddenAreas')
   get printViewClasses() {
-    // GA
-    if (this.enabled) {
-      this.get('metrics').trackEvent('GoogleAnalytics', {
-        eventCategory: 'Print',
-        eventAction: 'Enabled print view',
-        eventLabel: 'export',
-      });
-    }
-
     const orientation = this.printViewOrientation;
     const size = this.printViewPaperSize;
     const areas = this.printViewHiddenAreas;

--- a/app/templates/components/layer-record-views/zoning-district.hbs
+++ b/app/templates/components/layer-record-views/zoning-district.hbs
@@ -12,6 +12,7 @@
     <a
       href="https://www1.nyc.gov/site/planning/zoning/districts-tools/{{this.model.primaryzoneURL}}.page"
       target="_blank"
+      onclick={{action this.captureOutboundLink this.model.zonedist}}
     >
       {{fa-icon "external-link-alt"}}
       Learn more about
@@ -24,6 +25,7 @@
     <a
       href="https://www1.nyc.gov/site/planning/zoning/districts-tools/special-purpose-districts-manhattan.page#battery_park"
       target="_blank"
+      onclick={{action this.captureOutboundLink "Special Battery Park City"}}
     >
       {{fa-icon "external-link-alt"}}
       Learn more about the Special Battery Park City District&hellip;

--- a/app/templates/components/main-map.hbs
+++ b/app/templates/components/main-map.hbs
@@ -22,7 +22,7 @@
     <button
       class="mapboxgl-ctrl-icon"
       data-test-map-print-button
-      onClick={{action this.onPrint}}
+      onClick={{this.enablePrintView}}
     >
       {{fa-icon "print"}}
     </button>

--- a/app/templates/components/road-view.hbs
+++ b/app/templates/components/road-view.hbs
@@ -3,6 +3,7 @@
     class="button gray large reset-map-button hide-for-print"
     href={{this.url}}
     target="_blank"
+    onClick={{this.onClick}}
   >
     {{fa-icon "external-link-alt"}} Cyclomedia Street View
   </a>

--- a/app/utils/gtag.js
+++ b/app/utils/gtag.js
@@ -1,5 +1,5 @@
-export default function gtag(...args) {
+export default function gtag() {
   window.dataLayer = window.dataLayer || [];
-  window.dataLayer.push(args);
-  return args;
+  const event = arguments // eslint-disable-line
+  window.dataLayer.push(event);
 }

--- a/app/utils/gtag.js
+++ b/app/utils/gtag.js
@@ -1,0 +1,5 @@
+export default function gtag(...args) {
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(args);
+  return args;
+}

--- a/app/utils/gtag.js
+++ b/app/utils/gtag.js
@@ -1,5 +1,0 @@
-export default function gtag() {
-  window.dataLayer = window.dataLayer || [];
-  const event = arguments // eslint-disable-line
-  window.dataLayer.push(event);
-}

--- a/tests/index.html
+++ b/tests/index.html
@@ -7,6 +7,17 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-CL1BGY7RZM"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+    
+          gtag('config', 'G-CL1BGY7RZM', { 'debug_mode':true });
+          // gtag('config', 'G-CL1BGY7RZM');
+        </script>
+
     {{content-for "head"}}
     {{content-for "test-head"}}
 


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->



This PR implements Google Analytics 4 tagging.  This version uses the global gtag function and makes changes to eslint in order to pass tests.

Only known issue is 'download_bookmark' event is being double-counted. I have investigated and have no explanation for why it is occurring.

Closes #AB10276 and #AB9462

Changes to disable GA4 by default for dev/staging have been captured in #AB10573 and will be implemented at a future date.
