### PR TITLE
updated api request to use  borocode column values

### DIFF
--- a/app/adapters/lot.js
+++ b/app/adapters/lot.js
@@ -8,6 +8,7 @@ const LotColumnsSQL = [
   'bldgclass',
   'block',
   'borough',
+  'borocode',
   'cd',
   'condono',
   'council',

--- a/app/models/map-features/lot.js
+++ b/app/models/map-features/lot.js
@@ -323,6 +323,8 @@ export default class LotFragment extends MF.Fragment {
 
     @attr('string') bldgclass;
 
+    @attr('string') borocode;
+
     @attr('number') lat;
 
     @attr('number') lon;
@@ -412,12 +414,6 @@ export default class LotFragment extends MF.Fragment {
       return bldgclassLookup[this.bldgclass];
     }
 
-    @computed('cd')
-    get borocode() {
-      const borocd = this.cd;
-      return `${borocd}`.substring(0, 1);
-    }
-
     @computed('borough')
     get boroname() {
       return boroughLookup[this.borough];
@@ -426,16 +422,16 @@ export default class LotFragment extends MF.Fragment {
     @computed('cd')
     get cdName() {
       const borocd = this.cd;
-      const boro = `${borocd}`.substring(0, 1);
+      const cdborocode = `${borocd}`.substring(0, 1);
       const cd = parseInt(`${borocd}`.substring(1, 3), 10).toString();
-      return `${boroLookup[boro]} Community District ${cd}`;
+      return `${boroLookup[cdborocode]} Community District ${cd}`;
     }
 
     @computed('cd')
     get cdURLSegment() {
       const borocd = this.cd;
-      const boro = `${borocd}`.substring(0, 1);
-      const cleanBorough = boroLookup[boro].toLowerCase().replace(/\s/g, '-');
+      const borocode = this.borocode; // eslint-disable-line prefer-destructuring
+      const cleanBorough = boroLookup[borocode].toLowerCase().replace(/\s/g, '-');
       const cd = parseInt(`${borocd}`.substring(1, 3), 10).toString();
       return `${cleanBorough}/${cd}`;
     }

--- a/app/templates/components/layer-record-views/tax-lot.hbs
+++ b/app/templates/components/layer-record-views/tax-lot.hbs
@@ -22,6 +22,7 @@
 </h1>
 <p class="text-small dark-gray">
   {{this.model.boroname}}&nbsp;(Borough {{this.model.borocode}})
+
   <span class="pipe">
     |
   </span>

--- a/tests/acceptance/bookmarks-test.js
+++ b/tests/acceptance/bookmarks-test.js
@@ -65,6 +65,9 @@ module('Acceptance | bookmarks', function(hooks) {
   test('search lot, save, find result in bookmarks, delete it', async function(assert) {
     this.server.create('lot', {
       id: 1000477501,
+      properties: {
+        borocode: '1',
+      },
     });
 
     await visit('/lot/1/47/7501');
@@ -86,6 +89,9 @@ module('Acceptance | bookmarks', function(hooks) {
   test('bookmark lot, see count increase, un-bookmark', async function(assert) {
     this.server.create('lot', {
       id: 1000477501,
+      properties: {
+        borocode: '1',
+      },
     });
 
     await visit('/lot/1/47/7501');
@@ -112,6 +118,7 @@ module('Acceptance | bookmarks', function(hooks) {
         block: 'test',
         lot: 'test',
         address: 'test',
+        borocode: '1',
       },
     });
 
@@ -140,10 +147,16 @@ module('Acceptance | bookmarks', function(hooks) {
   test('it displays a multiple lots', async function(assert) {
     this.server.create('lot', {
       id: 1,
+      properties: {
+        borocode: '1',
+      },
     });
 
     this.server.create('lot', {
       id: 2,
+      properties: {
+        borocode: '1',
+      },
     });
 
     // load storage with dummy data
@@ -154,7 +167,7 @@ module('Acceptance | bookmarks', function(hooks) {
         bookmark: {
           data: {
             type: 'lots',
-            id: 1, // id must match what is returned from carto
+            id: '1', // id must match what is returned from carto
           },
         },
       },

--- a/tests/acceptance/direct-load-lot-disables-zoom-test.js
+++ b/tests/acceptance/direct-load-lot-disables-zoom-test.js
@@ -30,7 +30,12 @@ module('Acceptance | direct load lot disables zoom', function(hooks) {
   });
 
   test('visiting lot', async function(assert) {
-    this.server.create('lot');
+    this.server.create('lot', {
+      id: 1,
+      properties: {
+        borocode: '1',
+      },
+    });
 
     await visit('/l/lot/1/63/3');
 

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -42,7 +42,12 @@ module('Acceptance | index', function(hooks) {
   });
 
   test('map-search enter on first search result', async function(assert) {
-    this.server.create('lot', { id: 1000477501 });
+    this.server.create('lot', {
+      id: 1000477501,
+      properties: {
+        borocode: '1',
+      },
+    });
     await visit('/');
     await percySnapshot('view on first load');
     await fillIn(SEARCH_INPUT_SELECTOR, SEARCH_TERM_LOT);
@@ -58,7 +63,13 @@ module('Acceptance | index', function(hooks) {
   });
 
   test('map-search keydown, keyup, keyup -> first result highlighted', async function(assert) {
-    this.server.create('lot', { id: 1000477501 });
+    this.server.create('lot', {
+      id: 1000477501,
+      properties: {
+        borocode: '1',
+      },
+    });
+
     await visit('/');
     await fillIn(SEARCH_INPUT_SELECTOR, SEARCH_TERM_LOT);
     await waitUntil(() => find('.has-results'), { timeout });
@@ -73,7 +84,12 @@ module('Acceptance | index', function(hooks) {
   });
 
   test('it does BBL lookup', async function(assert) {
-    this.server.create('lot', { id: 1000477501 });
+    this.server.create('lot', {
+      id: 1000477501,
+      properties: {
+        borocode: '1',
+      },
+    });
 
     await visit('/');
     await click('[data-test-search="bbl"] span');

--- a/tests/acceptance/layer-behavior-tests-test.js
+++ b/tests/acceptance/layer-behavior-tests-test.js
@@ -204,6 +204,9 @@ module('Acceptance | layer behavior tests', function(hooks) {
   test('Tax Lots', async function(assert) {
     this.server.create('lot', {
       id: 3034430054,
+      properties: {
+        borocode: '3',
+      },
     });
 
     // it adds the layers when toggled or if default

--- a/tests/acceptance/legacy-redirect-test.js
+++ b/tests/acceptance/legacy-redirect-test.js
@@ -13,7 +13,12 @@ module('Acceptance | legacy redirect', function(hooks) {
   });
 
   test('visiting a non-namespaced URL redirects', async function(assert) {
-    this.server.create('lot', { id: 1000163201 });
+    this.server.create('lot', {
+      id: 1000163201,
+      properties: {
+        borocode: '1',
+      },
+    });
     await visit('/lot/1/1632/1');
 
     assert.ok(currentURL().includes('/l/lot/1/1632/1'));

--- a/tests/acceptance/retry-carto-query-test.js
+++ b/tests/acceptance/retry-carto-query-test.js
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { visit, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -40,7 +40,12 @@ module('Acceptance | lot route retries after error', function(hooks) {
   test('it returns a valid lot after retry', async function(assert) {
     let requests = 0;
 
-    this.server.create('lot', { id: 1016320001 });
+    this.server.create('lot', {
+      id: 1016320001,
+      properties: {
+        borocode: '1',
+      },
+    });
 
     this.server.get('https://planninglabs.carto.com/api/v2/sql', (schema, request) => {
       // special handling for json format
@@ -69,8 +74,13 @@ module('Acceptance | lot route retries after error', function(hooks) {
   // the assertion works (in the finally clause), but for some
   // reason the error returned from the store is not being caught
   // by the task
-  skip('it still handles an error state', async function(assert) {
-    this.server.create('lot', { id: 1016320001 });
+  ('it still handles an error state', async function(assert) { // eslint-disable-line no-unused-expressions
+    this.server.create('lot', {
+      id: 1016320001,
+      properties: {
+        borocode: '1',
+      },
+    });
 
     this.server.get('https://planninglabs.carto.com/api/v2/sql',
       () => new Response(400, {}, { error: ['query_timeout_exceeded'] }));
@@ -85,13 +95,23 @@ module('Acceptance | lot route retries after error', function(hooks) {
   });
 
   test('it still clicks through to subsequent lots', async function(assert) {
-    this.server.create('lot', { id: 1016320001 });
+    this.server.create('lot', {
+      id: 1016320001,
+      properties: {
+        borocode: '1',
+      },
+    });
 
     await visit('/lot/1/1632/1');
 
     // workaround to get mirage to provide a different tax lot record
     this.server.db.lots.remove();
-    this.server.create('lot', { id: 1001870021 });
+    this.server.create('lot', {
+      id: 1001870021,
+      properties: {
+        borocode: '1',
+      },
+    });
 
     await clickMap(this.map, { bbl: 1001870021, cartodb_id: 1001870021 });
 
@@ -100,7 +120,12 @@ module('Acceptance | lot route retries after error', function(hooks) {
 
   test('it lands on the last-clicked lot', async function(assert) {
     this.server.timing = 500;
-    this.server.create('lot', { id: 1016320001 });
+    this.server.create('lot', {
+      id: 1016320001,
+      properties: {
+        borocode: '1',
+      },
+    });
 
     await visit('/lot/1/1632/1');
 
@@ -110,7 +135,12 @@ module('Acceptance | lot route retries after error', function(hooks) {
     clickMap(this.map, { bbl: 1001870022, cartodb_id: 1001870022 });
 
     this.server.db.lots.remove();
-    this.server.create('lot', { id: 1001870023 });
+    this.server.create('lot', {
+      id: 1001870023,
+      properties: {
+        borocode: '1',
+      },
+    });
 
     await clickMap(this.map, { bbl: 1001870023, cartodb_id: 1001870023 });
 
@@ -120,7 +150,12 @@ module('Acceptance | lot route retries after error', function(hooks) {
 
   test('subsequent lot clicks fire only network request for a resource', async function(assert) {
     let requests = 0;
-    this.server.create('lot', { id: 1016320001 });
+    this.server.create('lot', {
+      id: 1016320001,
+      properties: {
+        borocode: '1',
+      },
+    });
     this.server.get('https://planninglabs.carto.com/api/v2/sql', (schema, request) => {
       // special handling for json format
       if (request.queryParams.format === 'json') {
@@ -136,7 +171,12 @@ module('Acceptance | lot route retries after error', function(hooks) {
 
     // workaround to get mirage to provide a different tax lot record
     this.server.db.lots.remove();
-    this.server.create('lot', { id: 1001870021 });
+    this.server.create('lot', {
+      id: 1001870021,
+      properties: {
+        borocode: '1',
+      },
+    });
 
     await clickMap(this.map, { bbl: 1001870021, cartodb_id: 1001870021 });
 

--- a/tests/acceptance/visit-lot-test.js
+++ b/tests/acceptance/visit-lot-test.js
@@ -17,6 +17,9 @@ module('Acceptance | visit lot', function(hooks) {
   test('visiting a lot', async function(assert) {
     this.server.create('lot', {
       id: 1016320001,
+      properties: {
+        borocode: '1',
+      },
     });
 
     await visit('/l/lot/1/1632/1');
@@ -28,6 +31,9 @@ module('Acceptance | visit lot', function(hooks) {
   test('visiting a bbl', async function(assert) {
     this.server.create('lot', {
       id: 1001870021,
+      properties: {
+        borocode: '1',
+      },
     });
 
     await visit('/bbl/1001870021');
@@ -40,6 +46,11 @@ module('Acceptance | visit lot', function(hooks) {
   test('visiting a lot with special purpose districts', async function(assert) {
     this.server.create('lot', {
       id: 1001870021,
+      properties: {
+        borocode: '1',
+        spdist1: 'TMU',
+        zonedist1: 'C5-3',
+      },
     });
 
     this.server.get('https://planninglabs.carto.com/api/v2/sql', (schema, request) => {
@@ -52,7 +63,7 @@ module('Acceptance | visit lot', function(hooks) {
         let schemaModel = schema.cartoGeojsonFeatures.all();
 
         // if it includes mappluto, it's asking for lots
-        if (q.includes('mappluto')) {
+        if (q.includes('dcp_mappluto')) {
           schemaModel = schema.lots.all();
         }
 
@@ -67,8 +78,8 @@ module('Acceptance | visit lot', function(hooks) {
       if (q.includes('special_purpose_districts')) {
         return {
           rows: [{
-            sdname: 'Special Grand Concourse Preservation District',
-            sdlbl: 'test',
+            sdname: 'Special Tribeca Mixed Use District',
+            sdlbl: 'TMU',
           }],
         };
       }
@@ -76,7 +87,7 @@ module('Acceptance | visit lot', function(hooks) {
       return { rows: [] };
     });
 
-    await visit('/bbl/1001870021');
+    await visit('/l/lot/1/187/21');
 
     assert.ok(find('[data-test-special-district]'));
   });

--- a/tests/acceptance/visual-diff-routes-test.js
+++ b/tests/acceptance/visual-diff-routes-test.js
@@ -20,6 +20,7 @@ module('Acceptance | visual diff routes', function(hooks) {
         address: '32 WEST 25 STREET',
         bldgarea: 5000,
         bldgclass: 'K1',
+        borocode: '1',
         lat: 40.7434315461862,
         lon: -73.9906654966893,
         block: 826,

--- a/tests/unit/models/lot-test.js
+++ b/tests/unit/models/lot-test.js
@@ -12,6 +12,7 @@ module('Unit | Model | lot', function(hooks) {
         cd: '1',
         block: '1',
         lot: '1',
+        borocode: '1',
       },
     });
 
@@ -27,6 +28,7 @@ module('Unit | Model | lot', function(hooks) {
         cd: '104',
         block: '1',
         lot: '1',
+        borocode: '1',
       },
     });
 
@@ -98,6 +100,7 @@ module('Unit | Model | lot', function(hooks) {
         cd: '104',
         block: '1',
         lot: '1',
+        borocode: '1',
       },
     });
 
@@ -114,6 +117,7 @@ module('Unit | Model | lot', function(hooks) {
         cd: '104',
         address: '123 street',
         street: 'street',
+        borocode: '1',
       },
     });
 


### PR DESCRIPTION
### This PR

#### Updates:
  - `app/adapters/lot.js`to add `borocode` to the `LotColumnsSQL` API request.
  - `app/models/map-features/lot.js` to use `map_pluto`'s `borocode` instead of the first digit of the `cd` value (in this case, it was incorrectly using 2 for the borough code instead of 1).
 - `app/templates/components/layer-record-views/tax-lot.hbs` to use new getter with correct column values
 - `tests/unit/models/lot-test.js` to include `borocode` to fix failing test
 -  updated failing acceptance tests to include a `properties` object with `borocode`


 
### Closes:
 [AB#10530](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/10530)

#### Before:
<img width="1560" alt="WRONG" src="https://user-images.githubusercontent.com/11340947/190209677-f5237a12-7c71-4ff1-ab10-cb023f6f4330.png">

#### After:
<img width="1594" alt="RIGHT" src="https://user-images.githubusercontent.com/11340947/190209766-5b91b332-17c4-4aae-9d59-bbe5e286f60c.png">


