### PR TITLE
3799 Upgrade labs-ember-search to version with correct boro field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "fastboot": "2.0.1",
     "foundation-sites": "6.5.0-rc.4",
     "husky": "^6.0.0",
-    "labs-ember-search": "^3.1.5",
+    "labs-ember-search": "3.1.6",
     "labs-ui": "^0.0.24",
     "lint-staged": ">=10",
     "loader.js": "^4.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9629,10 +9629,10 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-labs-ember-search@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-3.1.5.tgz#dfc240b74da07b4b133448f23d9cea1843d3e6cd"
-  integrity sha512-Is3ZGrQNfU0z6iBtqjsxplqEvOR1EnGpWCtJ1yS/obMhwbJaENgJKd3Ovu4KRJ28tnLQedQsq56eeyqMNnCzoQ==
+labs-ember-search@3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/labs-ember-search/-/labs-ember-search-3.1.6.tgz#18891fe83fca585655d3e19433e5907228f209f1"
+  integrity sha512-DeyuRHjb0Le+3GqYcdiJWBvNFVZ5p//+fo4d9YlkJWacIQuDWOjSQ2fS/FVRe/9ySCdQiLFVOa+PukvFzgyJ3Q==
   dependencies:
     "@fortawesome/ember-fontawesome" "^0.1.9"
     "@fortawesome/free-regular-svg-icons" "^5.7.1"


### PR DESCRIPTION
This PR upgrades the dependency on labs-ember-search to v3.1.6. This new version of labs-ember-search has the change in [this PR](https://github.com/NYCPlanning/labs-ember-search/pull/46/files) so that we are using the correct boro field name in dof_dtm_block_centroids.