### PR TITLE
10753 Disable GA4 by default for development and staging

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -14,8 +14,10 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      // gtag('config', 'G-CL1BGY7RZM', { 'debug_mode':true });
-      gtag('config', 'G-CL1BGY7RZM');
+      if(window.location.hostname.includes('zola') && (!window.location.hostname.includes('preview'))) {
+        // gtag('config', 'G-CL1BGY7RZM', { 'debug_mode':true });
+        gtag('config', 'G-CL1BGY7RZM');
+      }
     </script>
  
     <!-- Twitter Card -->


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This changes the index.html so that Google Analytics is only provided the account id that it needs to store the data if the hostname includes 'zola' and does not include 'preview'.

Closes #AB10753
