### PR TITLE
Fix environment.js to correctly set ember search config for prod builds

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -374,17 +374,13 @@ module.exports = function(environment) {
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
 
-    ENV['labs-search'] = {
-      host: 'https://search-api-staging.herokuapp.com',
-    };
+    ENV['labs-search'].host = 'https://search-api-staging.herokuapp.com';
 
     ENV.host = '';
   }
 
   if (environment === 'production') {
-    ENV['labs-search'] = {
-      host: 'https://search-api-production.herokuapp.com',
-    };
+    ENV['labs-search'].host = 'https://search-api-production.herokuapp.com';
   }
 
   return ENV;


### PR DESCRIPTION
## Summary
This PR tweaks environment.js for the geosearch v2 upgrades. Before this change, ENV['labs-search'] was incorrectly getting overwritten entirely in production builds which causes the new geosearch v2 helper to not be used.
