### PR TITLE
11298 fix data qa carto domain

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const HOST = process.env.API_HOST || 'https://layers-api.planninglabs.nyc';
+const CARTO_USER = process.env.CARTO_USER || 'planninglabs';
 
 module.exports = function(environment) {
   const ENV = {
@@ -282,8 +283,8 @@ module.exports = function(environment) {
     },
 
     carto: {
-      username: 'planninglabs',
-      domain: 'https://planninglabs.carto.com',
+      username: CARTO_USER,
+      domain: `https://${CARTO_USER}.carto.com`,
     },
 
     fontawesome: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 command = "API_HOST=https://layers-api-staging.planninglabs.nyc yarn build --environment=production"
 
 [context.data-qa]
-command = "API_HOST=https://layers-api-data.planninglabs.nyc yarn build --environment=production"
+command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-data.planninglabs.nyc yarn build --environment=production"
 
 [context.master]
 command = "yarn build --environment=production"


### PR DESCRIPTION
This PR fixes an issue where our calls to the Carto sql api are still incorrectly querying the `planninglabs` instance in the data-qa environment (https://data-qa--labs-zola.netlify.app/), instead of the `dcpadmin` one. That environment is correctly using `dcpadmin` when getting vector tiles, this change will just get the SQL api calls in sync with that.