### PR TITLE
12132 Add link to ZAP Search to the ULURP IDs

### DIFF
--- a/app/routes/map-feature/zoning-map-amendment.js
+++ b/app/routes/map-feature/zoning-map-amendment.js
@@ -1,13 +1,20 @@
 import Route from '@ember/routing/route';
+import fetch from 'node-fetch';
+import config from 'labs-zola/config/environment';
 
 export default class ZoningDistrictRoute extends Route {
-  model(params) {
+  async model(params) {
     const { id } = params;
     const { search } = this.paramsFor('map-feature');
+
+    const response = await fetch(`${config.zapApiHost}/projects?action-ulurpnumber[]=${id}`);
+    const ulurp = await response.json();
+    const zapId = (ulurp.data.length === 1) ? ulurp.data[0].id : null;
 
     return {
       id,
       search,
+      zapId,
     };
   }
 }

--- a/app/routes/map-feature/zoning-map-amendment.js
+++ b/app/routes/map-feature/zoning-map-amendment.js
@@ -7,14 +7,22 @@ export default class ZoningDistrictRoute extends Route {
     const { id } = params;
     const { search } = this.paramsFor('map-feature');
 
-    const response = await fetch(`${config.zapApiHost}/projects?action-ulurpnumber[]=${id}`);
-    const ulurp = await response.json();
-    const zapId = (ulurp.data.length === 1) ? ulurp.data[0].id : null;
+    try {
+      const response = await fetch(`${config.zapApiHost}/projects?action-ulurpnumber[]=${id}`);
+      const ulurp = await response.json();
+      const zapId = (ulurp.data.length === 1) ? ulurp.data[0].id : null;
 
-    return {
-      id,
-      search,
-      zapId,
-    };
+      return {
+        id,
+        search,
+        zapId,
+      };
+    } catch (e) {
+      console.error('Could not query ULURP', e); // eslint-disable-line
+      return {
+        id,
+        search,
+      };
+    }
   }
 }

--- a/app/templates/components/layer-record-views/zoning-map-amendment.hbs
+++ b/app/templates/components/layer-record-views/zoning-map-amendment.hbs
@@ -9,7 +9,17 @@
     ULURP Number
   </label>
   <span class="datum">
-    {{this.model.ulurpno}}
+    {{#if this.zapId}}
+      <a
+        target="_blank"
+        href="https://zap.planning.nyc.gov/projects/{{this.zapId}}"
+      >
+        {{this.model.ulurpno}}
+        {{fa-icon "external-link-alt" transform="shrink-3 up-1"}}
+      </a>
+    {{else}}
+      {{this.model.ulurpno}}
+    {{/if}}
   </span>
 </div>
 <div class="data-grid">
@@ -39,7 +49,6 @@
       target="_blank"
       href="http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/sketchmaps/skz{{this.model.ulurpno}}.pdf"
     >
-      {{fa-icon "file-pdf-o"}}
       {{this.model.ulurpno}}
       <small>
         (PDF)

--- a/app/templates/map-feature/zoning-map-amendment.hbs
+++ b/app/templates/map-feature/zoning-map-amendment.hbs
@@ -11,5 +11,6 @@
   />
   <LayerRecordViews::ZoningMapAmendment
     @model={{zoningMapAmendment.properties}}
+    @zapId={{this.model.zapId}}
   />
 </CartoDataProvider>

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,6 +10,7 @@ module.exports = function(environment) {
     locationType: 'auto',
     host: HOST,
     namespace: 'v1',
+    zapApiHost: 'https://zap-api-production.herokuapp.com',
 
     gReCaptcha: {
       jsUrl: 'https://www.google.com/recaptcha/api.js?render=explicit',

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -26,6 +26,7 @@ export default function() {
     http://www.ember-cli-mirage.com/docs/v0.4.x/shorthands/
   */
 
+  this.passthrough('https://zap-api-production.herokuapp.com/**');
   this.passthrough('/img/ht.png');
   this.passthrough('https://labs-mapbox-gl-noop-tiles.nyc3.digitaloceanspaces.com/**');
 


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->
When viewing a Zoning Map Amendment, the ULURP number links to ZAP Search page for appropriate project.

If the API does not return exactly 1 result, or the network request fails, the text will remain as it was previously.


Closes [AB#12132](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/12132)
