### PR TITLE
11999 – Add E-Designation info panel

### DIFF
--- a/app/adapters/e-designation.js
+++ b/app/adapters/e-designation.js
@@ -1,0 +1,24 @@
+import { buildSqlUrl } from '../utils/carto';
+import CartoGeojsonFeatureAdapter from './carto-geojson-feature';
+
+const SQL = function(bbl) {
+  return `SELECT e.the_geom,
+        e.cartodb_id AS id,
+        e.cartodb_id,
+        e.bbl,
+        e.ceqr_num,
+        e.enumber,
+        e.ulurp_num,
+        b.address
+    FROM dcp_e_designations AS e, dcp_mappluto AS b
+    WHERE e.bbl='${bbl}' AND b.bbl='${bbl}'`;
+};
+
+export default CartoGeojsonFeatureAdapter.extend({
+  urlForFindRecord(id) {
+    return buildSqlUrl(
+      SQL(id),
+      'geojson',
+    );
+  },
+});

--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -258,8 +258,8 @@ export default class MainMap extends Component {
           this.router.transitionTo('map-feature.commercial-overlay', overlay, { queryParams: { search: false } });
         }
 
-        if (ceqr_num) { // eslint-disable-line
-          window.open(`https://zap-api.planninglabs.nyc/ceqr/${ceqr_num}`, '_blank'); // eslint-disable-line
+        if (bbl && ceqr_num) {
+          this.router.transitionTo('map-feature.e-designation', bbl, { queryParams: { search: false } });
         }
       }
     }

--- a/app/models/e-designation.js
+++ b/app/models/e-designation.js
@@ -1,0 +1,10 @@
+import {
+  fragment,
+} from 'ember-data-model-fragments/attributes';
+// import { alias } from '@ember/object/computed';
+import CartoGeojsonFeature from './carto-geojson-feature';
+
+export default class EDesignation extends CartoGeojsonFeature {
+    @fragment('map-features/e-designation')
+    properties;
+}

--- a/app/models/map-features/e-designation.js
+++ b/app/models/map-features/e-designation.js
@@ -1,0 +1,18 @@
+import DS from 'ember-data';
+import MF from 'ember-data-model-fragments';
+
+const { attr } = DS;
+
+export default class EDesignationFragment extends MF.Fragment {
+    @attr('string')
+    address;
+
+    @attr('string')
+    ceqr_num;
+
+    @attr('string')
+    enumber;
+
+    @attr('string')
+    ulurp_num;
+}

--- a/app/router.js
+++ b/app/router.js
@@ -26,6 +26,7 @@ Router.map(function () {// eslint-disable-line
     this.route('special-purpose-district', { path: '/special-purpose-district/:id' });
     this.route('special-purpose-subdistrict', { path: '/special-purpose-subdistrict/:id' });
     this.route('zoning-map-amendment', { path: '/zma/:id' });
+    this.route('e-designation', { path: '/e-designation/:id' });
   });
 
   // in order to namespace the map feature routes (zoning district, etc), we have

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -234,6 +234,12 @@ body.index {
   border: 0;
 }
 
+.ceqr-access {
+  width: 100%;
+  height:48px;
+  border: 0;
+}
+
 #browser-unsupported {
   display: none;
   opacity: 0.8;

--- a/app/templates/components/layer-record-views/e-designation.hbs
+++ b/app/templates/components/layer-record-views/e-designation.hbs
@@ -1,0 +1,53 @@
+<label class="header-type">
+    E-DESIGNATION
+</label>
+<h1 class="header-large">
+    {{this.model.address}}
+</h1>
+<p>
+    A property with an E-designation means that, as a consequence of a zoning action, a property has environmental requirements relating to air, noise or hazardous materials that must be investigated and addressed before an owner can obtain a building permit for the property's redevelopment. To learn more about E-Designations and environmental cleanup, 
+    <a href="https://www.nyc.gov/site/oer/remediation/city-environmental-quality-review.page" target="_blank">
+    click here.
+    </a>
+</p>
+<hr class="hide-for-print">
+<h2 class="header-large">
+    E-Designation Information
+</h2>
+<div class="data-grid">
+    <label class="data-label">
+        CEQR Number
+    </label>
+    <span class="datum">
+          {{this.model.ceqr_num}}
+      </span>
+</div>
+<div class="data-grid">
+    <label class="data-label">
+        E-Number
+    </label>
+    <span class="datum">
+          {{this.model.enumber}}
+      </span>
+</div>
+<div class="data-grid">
+    <label class="data-label">
+        ULURP Number
+    </label>
+    <span class="datum">
+          {{this.model.ulurp_num}}
+      </span>
+</div>
+<br>
+<p>
+    To learn more about this project and its associated E-Designation, click the link below to open CEQR Access. Enter the CEQR Number listed above into the CEQR Number input on that page and click Search.
+</p>
+<div class="ceqr-access hide-for-print">
+  <a
+    class="button gray large reset-map-button hide-for-print"
+    href="https://www.nyc.gov/site/oer/remediation/city-environmental-quality-review.page"
+    target="_blank"
+  >
+    {{fa-icon "external-link-alt"}} CEQR Access
+  </a>
+</div>

--- a/app/templates/map-feature/e-designation.hbs
+++ b/app/templates/map-feature/e-designation.hbs
@@ -1,0 +1,13 @@
+<CartoDataProvider
+    @modelId={{this.model.id}}
+    @modelName="e-designation" as |eDesignation|
+>
+    <Mapbox::MapFeatureRenderer 
+        @model={{eDesignation}}
+    />
+
+<LayerRecordViews::EDesignation
+    @model={{eDesignation.properties}}
+  />
+
+</CartoDataProvider>


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

Adds a new info panel for E-Designations displaying new copy and unique feature identifiers such as CEQR, E-Number, and ULURP numbers.

Related to tooltip changes in [this PR](https://github.com/NYCPlanning/labs-layers-api/pull/297) in labs-layers-api.

Closes AB[#11999](https://dev.azure.com/NYCPlanning/ITD/_sprints/taskboard/Open%20Source%20Engineering/ITD/23C?workitem=11999)

<img width="1440" alt="edes" src="https://user-images.githubusercontent.com/43344288/217557330-f1dca1fd-fc61-41b0-97ec-9ad92ece6a2d.png">
