### PR TITLE
Remove test run from GH action until we get it working with node ugprades

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,5 +19,3 @@ jobs:
           node-version: 14.x
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
-      - name: test
-        run: yarn test


### PR DESCRIPTION
This PR removes a step from the GH action workflow that ran tests. These tests are failing to run in GH actions since [this PR](https://github.com/NYCPlanning/labs-zola/pull/1059) but they still work locally.