### PR TITLE
Fix e-designation panel

### DIFF
--- a/app/adapters/e-designation.js
+++ b/app/adapters/e-designation.js
@@ -18,7 +18,7 @@ export default CartoGeojsonFeatureAdapter.extend({
   urlForFindRecord(id) {
     return buildSqlUrl(
       SQL(id),
-      'geojson',
+      'json',
     );
   },
 });

--- a/app/adapters/e-designation.js
+++ b/app/adapters/e-designation.js
@@ -1,24 +1,21 @@
 import { buildSqlUrl } from '../utils/carto';
 import CartoGeojsonFeatureAdapter from './carto-geojson-feature';
 
-const SQL = function(bbl) {
+const SQL = function (id) {
   return `SELECT e.the_geom,
         e.cartodb_id AS id,
-        e.cartodb_id,
         e.bbl,
         e.ceqr_num,
         e.enumber,
         e.ulurp_num,
         b.address
-    FROM dcp_e_designations AS e, dcp_mappluto AS b
-    WHERE e.bbl='${bbl}' AND b.bbl='${bbl}'`;
+    FROM dcp_e_designations e
+    LEFT JOIN dcp_mappluto b on e.bbl = b.bbl
+    WHERE e.cartodb_id=${id};`;
 };
 
 export default CartoGeojsonFeatureAdapter.extend({
   urlForFindRecord(id) {
-    return buildSqlUrl(
-      SQL(id),
-      'json',
-    );
+    return buildSqlUrl(SQL(id), 'geojson');
   },
 });

--- a/app/components/layer-record-views/e-designation.js
+++ b/app/components/layer-record-views/e-designation.js
@@ -1,0 +1,3 @@
+import LayerRecordComponent from './-base';
+
+export default LayerRecordComponent;

--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -220,7 +220,6 @@ export default class MainMap extends Component {
 
     if (feature) {
       const { properties } = feature;
-      console.log('feature', feature);
 
       if (highlightedLayerId === feature.layer.id) {
         const {
@@ -230,6 +229,7 @@ export default class MainMap extends Component {
           sdlbl,
           splbl,
           overlay,
+          id,
           cartodb_id, // eslint-disable-line
           ceqr_num, // eslint-disable-line
         } = properties;
@@ -260,7 +260,7 @@ export default class MainMap extends Component {
         }
 
         if (bbl && ceqr_num) {
-          this.router.transitionTo('map-feature.e-designation', bbl, { queryParams: { search: false } });
+          this.router.transitionTo('map-feature.e-designation', id, { queryParams: { search: false } });
         }
       }
     }

--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -220,6 +220,7 @@ export default class MainMap extends Component {
 
     if (feature) {
       const { properties } = feature;
+      console.log('feature', feature);
 
       if (highlightedLayerId === feature.layer.id) {
         const {

--- a/app/models/e-designation.js
+++ b/app/models/e-designation.js
@@ -1,7 +1,6 @@
 import {
   fragment,
 } from 'ember-data-model-fragments/attributes';
-// import { alias } from '@ember/object/computed';
 import CartoGeojsonFeature from './carto-geojson-feature';
 
 export default class EDesignation extends CartoGeojsonFeature {

--- a/app/serializers/carto-geojson-feature.js
+++ b/app/serializers/carto-geojson-feature.js
@@ -17,7 +17,6 @@ export default class GeoJsonFeatureSerializer extends DS.JSONSerializer {
     } else {
       throw new Error(`cannot find record ${queryId} for ${primaryModelClass}`);
     }
-
     return super.normalizeFindRecordResponse(
       store,
       primaryModelClass,

--- a/app/serializers/e-designation.js
+++ b/app/serializers/e-designation.js
@@ -1,0 +1,30 @@
+import { assign } from '@ember/polyfills';
+import DS from 'ember-data';
+
+export default class EDesignation extends DS.JSONSerializer {
+  normalizeFindRecordResponse(store, primaryModelClass, payload, queryId, requestType) {
+    let newPayload = payload;
+    let newQueryId = queryId;
+
+    console.log('payload', payload);
+
+    if (payload.rows.length) {
+      const [feature] = payload.rows;
+
+      const { id } = feature;
+      newQueryId = id;
+
+      newPayload = assign(feature, { id });
+    } else {
+      throw new Error(`cannot find record ${queryId} for ${primaryModelClass}`);
+    }
+
+    return super.normalizeFindRecordResponse(
+      store,
+      primaryModelClass,
+      newPayload,
+      newQueryId,
+      requestType,
+    );
+  }
+}

--- a/app/serializers/e-designation.js
+++ b/app/serializers/e-designation.js
@@ -1,30 +1,3 @@
-import { assign } from '@ember/polyfills';
-import DS from 'ember-data';
+import CartoGeoJsonFeature from './carto-geojson-feature';
 
-export default class EDesignation extends DS.JSONSerializer {
-  normalizeFindRecordResponse(store, primaryModelClass, payload, queryId, requestType) {
-    let newPayload = payload;
-    let newQueryId = queryId;
-
-    console.log('payload', payload);
-
-    if (payload.rows.length) {
-      const [feature] = payload.rows;
-
-      const { id } = feature;
-      newQueryId = id;
-
-      newPayload = assign(feature, { id });
-    } else {
-      throw new Error(`cannot find record ${queryId} for ${primaryModelClass}`);
-    }
-
-    return super.normalizeFindRecordResponse(
-      store,
-      primaryModelClass,
-      newPayload,
-      newQueryId,
-      requestType,
-    );
-  }
-}
+export default CartoGeoJsonFeature;

--- a/app/templates/map-feature/e-designation.hbs
+++ b/app/templates/map-feature/e-designation.hbs
@@ -4,6 +4,7 @@
 >
     <Mapbox::MapFeatureRenderer 
         @model={{eDesignation}}
+        @shouldFitBounds={{this.model.search}}
     />
 
 <LayerRecordViews::EDesignation

--- a/app/templates/map-feature/e-designation.hbs
+++ b/app/templates/map-feature/e-designation.hbs
@@ -4,9 +4,8 @@
 >
     <Mapbox::MapFeatureRenderer 
         @model={{eDesignation}}
-        @shouldFitBounds={{this.model.search}}
     />
-
+    
 <LayerRecordViews::EDesignation
     @model={{eDesignation.properties}}
   />

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ember-in-viewport": "^3.1.3",
     "ember-load-initializers": "^2.1.1",
     "ember-local-storage": "2.0.2",
-    "ember-mapbox-composer": "0.4.0",
+    "ember-mapbox-composer": "0.5.0",
     "ember-mapbox-gl": "0.16.0",
     "ember-mapbox-gl-draw": "2.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7366,10 +7366,10 @@ ember-local-storage@2.0.2:
     ember-cli-version-checker "^2.1.0"
     ember-copy "^2.0.1"
 
-ember-mapbox-composer@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.4.0.tgz#fd0c4ca383777192d5a3e27231a38257833df56e"
-  integrity sha512-2CaZRvGTdJBS/I8n9STT2KtTT+bOgdF9ZovlRwPQm9F4hmwM0UXeGLayWV3dofNO/pU9ZLfA6k+v4tuxXNzhCg==
+ember-mapbox-composer@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/ember-mapbox-composer/-/ember-mapbox-composer-0.5.0.tgz#a3c4a0baa697e664e1ccc1bd5565e1ba95e5200a"
+  integrity sha512-so0XWK1emjwQkcB1UwCN5HK1uytXFFrr3v9bDyhks9JwqYUx2bEIgW8Jx9WUbewvBSkwgW06c/BEx4IISTtTLw==
   dependencies:
     "@turf/union" "^6.0.0"
     cartobox-promises-utility "1.0.2"


### PR DESCRIPTION
This PR is a fix for an issue with the new E-Designation panel introduced in #1097 wherein feature information fails to load. One suspected issue is the [carto-geojson-feature](https://github.com/NYCPlanning/labs-zola/blob/master/app/serializers/carto-geojson-feature.js) which seems to be using geometry that the E-Designation point features do not have. This fix is a new serializer for E-Designations.