### PR TITLE
Update netlify.toml to use staging Search API and Layers API when deploying to develop environment.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,9 @@
 [build]
 command = "API_HOST=https://layers-api-staging.planninglabs.nyc yarn build --environment=production"
 
+[context.develop]
+command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-staging.planninglabs.nyc yarn build --environment=development"
+
 [context.data-qa]
 command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-data.planninglabs.nyc yarn build --environment=production"
 


### PR DESCRIPTION
### Summary
This PR updates `netlify.toml` to set staging urls for layers api and search api when deployed to the `develop` netlify context 