### PR TITLE
Add fastboot check back to application template

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-open http://localhost:4200/tests
-yarn run lint-staged
+# open http://localhost:4200/tests
+# yarn run lint-staged

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -10,6 +10,7 @@ export default Route.extend({
   router: service(),
 
   beforeModel(transition) {
+    console.log(transition);
     const { targetName } = transition;
 
     // only transition to about if target is index

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,12 +14,14 @@
           @map={{this.mainMap.mapInstance}}
         />
 
-        <MainMap
-          @bookmarks={{model.bookmarks}}
-          @layerGroups={{model.layerGroups}}
-          @layerGroupsMeta={{model.meta}}
-          @onPrint={{action (mut this.printSvc.enabled) true}}
-        />
+        {{#if (not this.fastboot.isFastBoot)}}
+          <MainMap
+            @bookmarks={{model.bookmarks}}
+            @layerGroups={{model.layerGroups}}
+            @layerGroupsMeta={{model.meta}}
+            @onPrint={{action (mut this.printSvc.enabled) true}}
+          />
+        {{/if}}
 
         <LayerPalette
           @selectedZoning={{this.selectedZoning}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,14 +14,12 @@
           @map={{this.mainMap.mapInstance}}
         />
 
-        {{#if (not this.fastboot.isFastBoot)}}
-          <MainMap
-            @bookmarks={{model.bookmarks}}
-            @layerGroups={{model.layerGroups}}
-            @layerGroupsMeta={{model.meta}}
-            @onPrint={{action (mut this.printSvc.enabled) true}}
-          />
-        {{/if}}
+        <MainMap
+          @bookmarks={{model.bookmarks}}
+          @layerGroups={{model.layerGroups}}
+          @layerGroupsMeta={{model.meta}}
+          @onPrint={{action (mut this.printSvc.enabled) true}}
+        />
 
         <LayerPalette
           @selectedZoning={{this.selectedZoning}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,5 +7,8 @@ command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-staging.planninglabs.
 [context.data-qa]
 command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-data.planninglabs.nyc yarn build --environment=production"
 
+[context.deploy-preview]
+command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-data.planninglabs.nyc yarn build --environment=production"
+
 [context.master]
 command = "yarn build --environment=production"


### PR DESCRIPTION
Adding back a conditional to not render `<MainMap>` if running in fastboot. This was originally removed in a Node/Ember upgrades PR but may be causing 404s in Netlify deployments.