### PR TITLE
Remove netlifyredirects file

### DIFF
--- a/.netlifyredirects
+++ b/.netlifyredirects
@@ -1,3 +1,0 @@
-/    /index.html    200
-/about    /about/index.html    200
-/*    /_empty.html    200


### PR DESCRIPTION
This PR removes the `.netlifyredirects` file in an attempt to fix 404's we're seeing in lower environment deployments