### PR TITLE
POC: Streamline Netlify configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,17 @@
 [build]
-command = "API_HOST=https://layers-api-staging.planninglabs.nyc yarn build --environment=production"
+command = "yarn build"
 
 [context.develop]
-command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-staging.planninglabs.nyc yarn build --environment=development"
+command = "yarn build --environment=development"
+
+[context.develop.environment]
+CARTO_USER = "dcpadmin"
+API_HOST = "https://layers-api-staging.planninglabs.nyc"
 
 [context.data-qa]
-command = "CARTO_USER=dcpadmin API_HOST=https://layers-api-data.planninglabs.nyc yarn build --environment=production"
 
-[context.master]
-command = "yarn build --environment=production"
+[context.data-qa.environment]
+CARTO_USER = "dcpadmin"
+API_HOST = "https://layers-api-data.planninglabs.nyc"
+
+[context.production]


### PR DESCRIPTION
# Description
Looking through the netlify.toml documentation, there appeared to be an opportunity to streamline the configuration. This is meant as a point of discussion, without an expectation of adopting this refactor

Changes Proposed:
- Abbreviate `yarn build --environment=production` to `yarn build`
  - the default environment in `package.json` is already `production`
- Move variables into `context.[name].environment`
  -  Allows `command` to no longer be concerned with the environment variables
- Allow contexts that use a production build to fallback to `command` set in the `build` 
- Change `master` to `production`
   - Netlify UI is configured to look at a specific branch for the `production` environment
   - This allows use to change the deployment branch without updating the configuration each time
