### PR TITLE
Update links to regular and historical zoning maps to point to OTI media server

### DIFF
--- a/app/models/map-features/lot.js
+++ b/app/models/map-features/lot.js
@@ -546,12 +546,12 @@ export default class LotFragment extends MF.Fragment {
 
     @computed('zonemap')
     get zoningMapLink() {
-      return `http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map${this.zonemap}.pdf`;
+      return `https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/zoning/zoning-maps/map${this.zonemap}.pdf`;
     }
 
     @computed('paddedZonemap')
     get historicalZoningMapLink() {
-      return `http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/historical-zoning-maps/maps${this.paddedZonemap}.pdf`;
+      return `https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/zoning/zoning-maps/maps${this.paddedZonemap}.pdf`;
     }
 
     @computed('borocode', 'block', 'lot')

--- a/tests/unit/models/lot-test.js
+++ b/tests/unit/models/lot-test.js
@@ -76,7 +76,7 @@ module('Unit | Model | lot', function(hooks) {
     const model = await this.owner.lookup('service:store')
       .findRecord('lot', 1);
 
-    assert.equal(model.properties.zoningMapLink, 'http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/map8d.pdf');
+    assert.equal(model.properties.zoningMapLink, 'https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/zoning/zoning-maps/map8d.pdf');
   });
 
   test('it generates correct links: Historical Zoning Map', async function(assert) {
@@ -90,7 +90,7 @@ module('Unit | Model | lot', function(hooks) {
     const model = await this.owner.lookup('service:store')
       .findRecord('lot', 1);
 
-    assert.equal(model.properties.historicalZoningMapLink, 'http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/historical-zoning-maps/maps08d.pdf');
+    assert.equal(model.properties.historicalZoningMapLink, 'https://s-media.nyc.gov/agencies/dcp/assets/files/pdf/zoning/zoning-maps/maps08d.pdf');
   });
 
   test('it generates correct links: ACRIS', async function(assert) {


### PR DESCRIPTION
## Summary

This PR updates the links to regular and historical zoning maps that users see when they click on a tax lot to point to the files on the media server that MPE recently migrated them to.
