### PR TITLE
13835 404 error when trying to download saved Tax Lots (PLUTO) as: CSV or Shapefile

### DIFF
--- a/app/templates/components/bookmarks/types/lot.hbs
+++ b/app/templates/components/bookmarks/types/lot.hbs
@@ -19,7 +19,7 @@
       class="button gray tiny"
       onclick={{action this.captureBookmarkDownload "CSV" preventDefault=false}}
       href={{carto-download-link
-        "mappluto"
+        "dcp_mappluto"
         "bbl"
         (map-by "bookmark.id" items)
         "csv"
@@ -31,7 +31,7 @@
       class="button gray tiny"
       onclick={{action this.captureBookmarkDownload "Shapefile" preventDefault=false}}
       href={{carto-download-link
-        "mappluto"
+        "dcp_mappluto"
         "bbl"
         (map-by "bookmark.id" items)
         "shp"

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -40,7 +40,7 @@ export default function() {
       let schemaModel = schema.cartoGeojsonFeatures.all();
 
       // if it includes mappluto, it's asking for lots
-      if (q.includes('mappluto')) {
+      if (q.includes('dcp_mappluto')) {
         schemaModel = schema.lots.all();
       }
 
@@ -60,7 +60,9 @@ export default function() {
           const found = q.match(regex);
           const cartoIdentifier = found[0]?.split(':')[1];
           features = features.filter(f => f.id === cartoIdentifier);
-        } catch (e) {}
+        } catch (e) {
+          console.error('Mirage error: ', e);
+        }
       }
 
       return {

--- a/mirage/static-fixtures/layer-groups.js
+++ b/mirage/static-fixtures/layer-groups.js
@@ -5835,7 +5835,7 @@ export default {
         'source-layers': [
           {
             id: 'pluto',
-            sql: 'SELECT bbl AS id, the_geom_webmercator, bbl, lot, landuse, address, numfloors FROM mappluto',
+            sql: 'SELECT bbl AS id, the_geom_webmercator, bbl, lot, landuse, address, numfloors FROM dcp_mappluto',
           },
           {
             id: 'block-centroids',

--- a/scripts/sitemap.js
+++ b/scripts/sitemap.js
@@ -26,7 +26,7 @@ function createSitemap(rows) {
 
 function getData() {
   const offset = 50000 * count;
-  const sql = `SELECT bbl FROM mappluto LIMIT 50000 OFFSET ${offset}`;
+  const sql = `SELECT bbl FROM dcp_mappluto LIMIT 50000 OFFSET ${offset}`;
 
   const apiCall = `https://planninglabs.carto.com/api/v2/sql?q=${sql}&format=json`;
 
@@ -34,7 +34,7 @@ function getData() {
 
   request(apiCall, (err, response, body) => {
     const data = JSON.parse(body);
-    console.log(data);
+    console.log(data); // eslint-disable-line
     console.log(`Got ${data.rows.length} rows of data, building sitemap`) // eslint-disable-line
     createSitemap(data.rows);
   });

--- a/tests/integration/helpers/carto-download-link-test.js
+++ b/tests/integration/helpers/carto-download-link-test.js
@@ -1,7 +1,7 @@
 
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('helper:carto-download-link', function(hooks) {
@@ -10,7 +10,7 @@ module('helper:carto-download-link', function(hooks) {
   // Replace this with your real tests.
   test('it renders', async function(assert) {
     this.setProperties({
-      table: 'mappluto',
+      table: 'dcp_mappluto',
       identifier: 'bbl',
       ids: [1014970028, 1015280036, 1015280038],
       format: 'csv',
@@ -18,6 +18,6 @@ module('helper:carto-download-link', function(hooks) {
 
     await render(hbs`{{carto-download-link table identifier ids format}}`);
 
-    assert.equal(this.element.textContent.trim(), 'https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM mappluto WHERE bbl IN (1014970028,1015280036,1015280038)&format=csv&filename=mappluto');
+    assert.equal(this.element.textContent.trim(), 'https://planninglabs.carto.com/api/v2/sql?q=SELECT * FROM dcp_mappluto WHERE bbl IN (1014970028,1015280036,1015280038)&format=csv&filename=mappluto');
   });
 });


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->
Fixed this by updating Zola to use the "dcp_mappluto" table instead. That should fix this issue and ensure Zola is using the most up to date data.

Closes [AB#13835](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13835)
