### PR TITLE
14192 Add Matomo to ZoLa

### DIFF
--- a/app/components/bookmarks/bookmark-button.js
+++ b/app/components/bookmarks/bookmark-button.js
@@ -44,9 +44,10 @@ export default class BookmarkButton extends Component {
     });
 
     // GA
-    this.get('metrics').trackEvent('GoogleAnalytics', {
-      eventCategory: 'Bookmark',
-      eventAction: 'Used Bookmark',
+    this.get('metrics').trackEvent('MatomoTagManager', {
+      category: 'Bookmark',
+      action: 'Used Bookmark',
+      name: 'Used Bookmark',
     });
 
     const { bookmarkableModel } = this;

--- a/app/components/bookmarks/types/-default.js
+++ b/app/components/bookmarks/types/-default.js
@@ -30,10 +30,10 @@ export default class DefaultBookmark extends Component {
     });
 
     // GA
-    this.get('metrics').trackEvent('GoogleAnalytics', {
-      eventCategory: 'Download',
-      eventAction: `Downloaded Bookmark as ${format}`,
-      eventLabel: 'Export',
+    this.get('metrics').trackEvent('MatomoTagManager', {
+      category: 'Download',
+      action: `Downloaded Bookmark as ${format}`,
+      name: 'Export',
     });
   }
 }

--- a/app/components/bookmarks/types/-default.js
+++ b/app/components/bookmarks/types/-default.js
@@ -20,6 +20,11 @@ export default class DefaultBookmark extends Component {
       event_category: 'Bookmark',
       event_action: 'Deleted Bookmark',
     });
+    this.get('metrics').trackEvent('MatomoTagManager', {
+      category: 'Bookmark',
+      action: 'Delete',
+      name: 'Deleted Bookmark',
+    });
   }
 
   @action

--- a/app/components/labs-ui-overrides/layer-group-toggle.js
+++ b/app/components/labs-ui-overrides/layer-group-toggle.js
@@ -88,10 +88,10 @@ export default class LayerGroupToggle extends Component {
     });
 
     // GA
-    this.get('metrics').trackEvent('GoogleAnalytics', {
-      eventCategory: 'External Link',
-      eventAction: 'Clicked Supporting Zoning Link',
-      eventLabel: `Clicked ${label} Link`,
+    this.get('metrics').trackEvent('MatomoTagManager', {
+      category: 'External Link',
+      action: 'Clicked Supporting Zoning Link',
+      name: `Clicked ${label} Link`,
     });
   }
 }

--- a/app/components/layer-palette.js
+++ b/app/components/layer-palette.js
@@ -175,9 +175,10 @@ export default class LayerPaletteComponent extends Component {
     });
 
     // GA
-    this.get('metrics').trackEvent('GoogleAnalytics', {
-      eventCategory: 'Layers',
-      eventAction: `${ layerGroup.visible ? 'Turned on' : 'Turned off' } ${ layerGroup.legend.label }`,
+    this.get('metrics').trackEvent('MatomoTagManager', {
+      category: 'Layers',
+      action: `${ layerGroup.visible ? 'Turned on' : 'Turned off' } ${ layerGroup.legend.label }`,
+      name: `${ layerGroup.legend.label }`,
     });
     this.handleLayerGroupChange();
   }

--- a/app/components/layer-record-views/-base.js
+++ b/app/components/layer-record-views/-base.js
@@ -15,10 +15,10 @@ export default class LayerRecordBase extends Component {
       event_action: `Clicked ${label} Link`,
     });
     // GA
-    this.get('metrics').trackEvent('GoogleAnalytics', {
-      eventCategory: 'External Link',
-      eventAction: 'Clicked External Link',
-      eventLabel: `Clicked ${label} Link`,
+    this.get('metrics').trackEvent('MatomoTagManager', {
+      category: 'External Link',
+      action: 'Clicked External Link',
+      name: `Clicked ${label} Link`,
     });
   }
 }

--- a/app/components/locate-me-mobile.js
+++ b/app/components/locate-me-mobile.js
@@ -18,8 +18,8 @@ export default class LocateMeMobileComponent extends Component {
     if (geolocateButton) {
       // GA
       this.metrics.trackEvent(
-        'GoogleAnalytics',
-        { eventCategory: 'Map', eventAction: 'Geolocate on Mobile' },
+        'MatomoTagManager',
+        { category: 'Map', action: 'Geolocate on Mobile', name: 'Geolocate' },
       );
 
       geolocateButton.click();

--- a/app/components/main-map.js
+++ b/app/components/main-map.js
@@ -153,8 +153,8 @@ export default class MainMap extends Component {
     // GA
     geoLocateControl.on('trackuserlocationstart', () => {
       this.metrics.trackEvent(
-        'GoogleAnalytics',
-        { eventCategory: 'Map', eventAction: 'Geolocate' },
+        'MatomoTagManager',
+        { category: 'Map', action: 'Geolocate', name: 'Geolocate' },
       );
     });
 

--- a/app/components/map-measurement-tools.js
+++ b/app/components/map-measurement-tools.js
@@ -38,9 +38,10 @@ export default class MapMeasurementToolsComponent extends Component {
     });
 
     // GA
-    this.get('metrics').trackEvent('GoogleAnalytics', {
-      eventCategory: 'Measurement',
-      eventAction: 'Used measurement tool',
+    this.get('metrics').trackEvent('MatomoTagManager', {
+      category: 'Measurement',
+      action: 'Used measurement tool',
+      name: 'Measurement',
     });
 
     this.set('didStartDraw', true);

--- a/app/components/map-resource-search.js
+++ b/app/components/map-resource-search.js
@@ -24,9 +24,10 @@ export default class MapResourceSearchComponent extends Component {
       });
 
       // GA
-      this.get('metrics').trackEvent('GoogleAnalytics', {
-        eventCategory: 'Search',
-        eventAction: 'Used BBL Lookup',
+      this.get('metrics').trackEvent('MatomoTagManager', {
+        category: 'Search',
+        action: 'Used BBL Lookup',
+        name: 'Used BBL Lookup',
       });
 
       const { boro, block, lot } = bblDemux(bbl);
@@ -55,18 +56,20 @@ export default class MapResourceSearchComponent extends Component {
           event_category: 'Search',
           event_action: 'Searched by Address',
         });
-        this.get('metrics').trackEvent('GoogleAnalytics', {
-          eventCategory: 'Search',
-          eventAction: 'Searched by Address',
+        this.get('metrics').trackEvent('MatomoTagManager', {
+          category: 'Search',
+          action: 'Searched by Address',
+          name: 'Searched by Address',
         });
       } else {
         gtag('event', 'search', {
           event_category: 'Search',
           event_action: 'Used BBL Lookup',
         });
-        this.get('metrics').trackEvent('GoogleAnalytics', {
-          eventCategory: 'Search',
-          eventAction: 'Used BBL Lookup',
+        this.get('metrics').trackEvent('MatomoTagManager', {
+          category: 'Search',
+          action: 'Used BBL Lookup',
+          name: 'Used BBL Lookup',
         });
       }
 
@@ -86,9 +89,10 @@ export default class MapResourceSearchComponent extends Component {
         event_action: 'Searched by Zoning District',
       });
       // GA
-      this.get('metrics').trackEvent('GoogleAnalytics', {
-        eventCategory: 'Search',
-        eventAction: 'Searched by Zoning District',
+      this.get('metrics').trackEvent('MatomoTagManager', {
+        category: 'Search',
+        action: 'Searched by Zoning District',
+        name: 'Searched by Zoning District',
       });
 
       this.set('searchTerms', result.label);

--- a/app/components/print-view-controls.js
+++ b/app/components/print-view-controls.js
@@ -29,10 +29,10 @@ export default class PrintViewControls extends Component {
       event_action: 'Disabled print view',
     });
     // GA
-    this.get('metrics').trackEvent('GoogleAnalytics', {
-      eventCategory: 'Print',
-      eventAction: 'Disabled print view',
-      eventLabel: 'export',
+    this.get('metrics').trackEvent('MatomoTagManager', {
+      category: 'Print',
+      action: 'Disabled print view',
+      name: 'export',
     });
 
     this.set('printSvc.enabled', false);

--- a/app/mixins/track-page.js
+++ b/app/mixins/track-page.js
@@ -1,15 +1,15 @@
 import { inject as service } from '@ember/service';
 import Mixin from '@ember/object/mixin';
 import { scheduleOnce } from '@ember/runloop';
-import { on } from '@ember-decorators/object';
+import { on } from '@ember/object/evented';
 
 export default Mixin.create({
   metrics: service(),
 
-  @on('routeDidChange')
-  trackPage() {
+  trackPage: on('routeDidChange', function() {
     this._trackPage();
-  },
+  }),
+  
 
   _trackPage() {
     scheduleOnce('afterRender', this, () => {

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,6 +5,16 @@ const CARTO_USER = process.env.CARTO_USER || 'planninglabs';
 
 module.exports = function(environment) {
   const ENV = {
+    metricsAdapters: [
+      {
+        name: 'MatomoTagManager',
+        environments: ['development', 'production', 'test'],
+        config: {
+          matomoUrl: '165.227.109.77/matomo',
+          containerId: 'jmweCpOY',
+        },
+      },
+    ],
     modulePrefix: 'labs-zola',
     environment,
     rootURL: '/',
@@ -345,19 +355,7 @@ module.exports = function(environment) {
       },
     },
 
-    metricsAdapters: [
-      {
-        name: 'GoogleAnalytics',
-        environments: ['development', 'production'],
-        config: {
-          id: 'UA-84250233-8',
-          debug: environment === 'development-ga',
-          trace: environment === 'development-ga',
-          // Ensure development env hits aren't sent to GA
-          sendHitTask: (environment !== 'development' && environment !== 'devlocal'),
-        },
-      },
-    ],
+
 
     EmberENV: {
       FEATURES: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,7 +10,7 @@ module.exports = function(environment) {
         name: 'MatomoTagManager',
         environments: ['development', 'production', 'test'],
         config: {
-          matomoUrl: 'matomo-poc-f47265605236.herokuapp.com',
+          matomoUrl: 'matomo.planninglabs.nyc',
           containerId: '9G7PP94F',
         },
       },

--- a/config/environment.js
+++ b/config/environment.js
@@ -10,8 +10,8 @@ module.exports = function(environment) {
         name: 'MatomoTagManager',
         environments: ['development', 'production', 'test'],
         config: {
-          matomoUrl: '165.227.109.77/matomo',
-          containerId: 'jmweCpOY',
+          matomoUrl: 'matomo-poc-f47265605236.herokuapp.com',
+          containerId: '9G7PP94F',
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "ember-mapbox-gl": "^1.0.0",
     "ember-mapbox-gl-draw": "https://github.com/allthesignals/ember-mapbox-gl-draw#patch-3",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-metrics": "0.13.0",
+    "dcp-ember-metrics": "https://github.com/dhochbaum-dcp/dcp-ember-metrics#matomo-updates",
     "ember-native-dom-helpers": "^0.6.2",
     "ember-parachute": "1.0.2",
     "ember-promise-helpers": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "ember-mapbox-gl": "^1.0.0",
     "ember-mapbox-gl-draw": "https://github.com/allthesignals/ember-mapbox-gl-draw#patch-3",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "dcp-ember-metrics": "https://github.com/dhochbaum-dcp/dcp-ember-metrics#matomo-updates",
+    "dcp-ember-metrics": "https://github.com/dhochbaum-dcp/dcp-ember-metrics#rename",
     "ember-native-dom-helpers": "^0.6.2",
     "ember-parachute": "1.0.2",
     "ember-promise-helpers": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "ember-mapbox-gl": "^1.0.0",
     "ember-mapbox-gl-draw": "https://github.com/allthesignals/ember-mapbox-gl-draw#patch-3",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "dcp-ember-metrics": "https://github.com/dhochbaum-dcp/dcp-ember-metrics#rename",
+    "dcp-ember-metrics": "https://github.com/dhochbaum-dcp/dcp-ember-metrics",
     "ember-native-dom-helpers": "^0.6.2",
     "ember-parachute": "1.0.2",
     "ember-promise-helpers": "^1.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6107,7 +6107,7 @@ date-time@^2.1.0:
 
 "dcp-ember-metrics@https://github.com/dhochbaum-dcp/dcp-ember-metrics#matomo-updates":
   version "2.0.0-beta.1"
-  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#da63d7e350a9b0074d67a63fd5804b7838f40206"
+  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#378f46a472d7df8e3277da992f931a0b7f86a49c"
   dependencies:
     broccoli-funnel "^3.0.2"
     ember-cli-babel "^7.26.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4465,7 +4465,7 @@ broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1, broccoli-funnel@^2.0.2:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^3.0.3, broccoli-funnel@^3.0.5, broccoli-funnel@^3.0.8:
+broccoli-funnel@^3.0.2, broccoli-funnel@^3.0.3, broccoli-funnel@^3.0.5, broccoli-funnel@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.8.tgz#f5b62e2763c3918026a15a3c833edc889971279b"
   integrity sha512-ng4eIhPYiXqMw6SyGoxPHR3YAwEd2lr9FgBI1CyTbspl4txZovOsmzFkMkGAlu88xyvYXJqHiM2crfLa65T1BQ==
@@ -6105,6 +6105,14 @@ date-time@^2.1.0:
   dependencies:
     time-zone "^1.0.0"
 
+"dcp-ember-metrics@https://github.com/dhochbaum-dcp/dcp-ember-metrics#matomo-updates":
+  version "2.0.0-beta.1"
+  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#da63d7e350a9b0074d67a63fd5804b7838f40206"
+  dependencies:
+    broccoli-funnel "^3.0.2"
+    ember-cli-babel "^7.26.6"
+    ember-cli-typescript "^5.1.1"
+
 debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -6640,7 +6648,7 @@ ember-cli-babel@6.14.1:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.2:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -7099,7 +7107,7 @@ ember-cli-typescript@^4.1.0, ember-cli-typescript@^4.2.0, ember-cli-typescript@^
     stagehand "^1.0.0"
     walk-sync "^2.2.0"
 
-ember-cli-typescript@^5.0.0:
+ember-cli-typescript@^5.0.0, ember-cli-typescript@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz#553030f1ce3e8958b8e4fc34909acd1218cb35f2"
   integrity sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==
@@ -7424,13 +7432,6 @@ ember-export-application-global@^2.0.1:
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
   integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
 
-ember-factory-for-polyfill@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
-  integrity sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-
 ember-fetch@^8.1.1, ember-fetch@^8.1.2:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-8.1.2.tgz#651839780519319309127054786bf35cd4b84543"
@@ -7475,14 +7476,6 @@ ember-get-config@1.1.0, ember-get-config@^1.0.0, ember-get-config@^1.0.2:
   dependencies:
     "@embroider/macros" "^0.50.0 || ^1.0.0"
     ember-cli-babel "^7.26.6"
-
-ember-getowner-polyfill@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
-  integrity sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==
-  dependencies:
-    ember-cli-version-checker "^2.1.0"
-    ember-factory-for-polyfill "^1.3.1"
 
 ember-in-element-polyfill@^0.2.0:
   version "0.2.2"
@@ -7573,16 +7566,6 @@ ember-maybe-in-element@^2.0.3:
     ember-cli-babel "^7.26.11"
     ember-cli-htmlbars "^6.1.1"
     ember-cli-version-checker "^5.1.2"
-
-ember-metrics@0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-0.13.0.tgz#1dccf74c0cd628f6dcabce076d81258e9a8bd7af"
-  integrity sha512-N/EHwqfKzthe7wPK4Rz0MYCl9pxvC+Ld/WhZD/guyeHyHFIYlwI3f1RVyEcWEZ4+m2HcNYafK2QVl8d6Ff1aAg==
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    ember-cli-babel "^6.6.0"
-    ember-getowner-polyfill "^2.0.0"
-    ember-runtime-enumerable-includes-polyfill "^2.0.0"
 
 ember-modifier-manager-polyfill@^1.2.0:
   version "1.2.0"
@@ -7691,14 +7674,6 @@ ember-router-generator@^2.0.0:
     "@babel/parser" "^7.4.5"
     "@babel/traverse" "^7.4.5"
     recast "^0.18.1"
-
-ember-runtime-enumerable-includes-polyfill@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-2.1.0.tgz#dc6d4a028471e4acc350dfd2a149874fb20913f5"
-  integrity sha512-au18iI8VbEDYn3jLFZzETnKN5ciPgCUxMRucEP3jkq7qZ6sE0FVKpWMPY/h9tTND3VOBJt6fgPpEBJoJVCUudg==
-  dependencies:
-    ember-cli-babel "^6.9.0"
-    ember-cli-version-checker "^2.1.0"
 
 ember-source-channel-url@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6105,9 +6105,9 @@ date-time@^2.1.0:
   dependencies:
     time-zone "^1.0.0"
 
-"dcp-ember-metrics@https://github.com/dhochbaum-dcp/dcp-ember-metrics#rename":
-  version "2.0.0-beta.1"
-  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#6395581b2dae2b02595341e5b9baa4ccba60a1c8"
+"dcp-ember-metrics@https://github.com/dhochbaum-dcp/dcp-ember-metrics":
+  version "1.0.0"
+  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#a9eb880202e863133d27bf19789b8c3e848c5bad"
   dependencies:
     broccoli-funnel "^3.0.2"
     ember-cli-babel "^7.26.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6105,9 +6105,9 @@ date-time@^2.1.0:
   dependencies:
     time-zone "^1.0.0"
 
-"dcp-ember-metrics@https://github.com/dhochbaum-dcp/dcp-ember-metrics#matomo-updates":
+"dcp-ember-metrics@https://github.com/dhochbaum-dcp/dcp-ember-metrics#rename":
   version "2.0.0-beta.1"
-  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#378f46a472d7df8e3277da992f931a0b7f86a49c"
+  resolved "https://github.com/dhochbaum-dcp/dcp-ember-metrics#6395581b2dae2b02595341e5b9baa4ccba60a1c8"
   dependencies:
     broccoli-funnel "^3.0.2"
     ember-cli-babel "^7.26.6"


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR adds our self-hosted Matomo Tag Manager to ZoLa

Closes [AB#14192](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14192)
