### PR TITLE
14799 Remove date references in ZoLa Data infomation tab

### DIFF
--- a/app/templates/data.hbs
+++ b/app/templates/data.hbs
@@ -30,12 +30,6 @@
               </span>
             {{/each}}
           {{/if}}
-          {{#if layerGroup.meta.updated_at}}
-            <span style="display:block;" class="dark-gray text-small">
-              Updated in ZoLa:
-              {{layerGroup.meta.updated_at}}
-            </span>
-          {{/if}}
         </p>
       </li>
     {{/each}}


### PR DESCRIPTION
#### Summary:

This PR removes the `Updated in ZoLa: ${updated_at}` from the Data Source information page

#### Closes:
[AB#14799](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/14977)
