### PR TITLE
1155 Update ZOLA DTM link

### DIFF
--- a/app/components/layer-record-views/tax-lot.js
+++ b/app/components/layer-record-views/tax-lot.js
@@ -441,7 +441,7 @@ export default class TaxLotRecordComponent extends LayerRecordComponent {
   }
 
   get digitalTaxMapLink() {
-    return `http://maps.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=${this.model.bbl}`;
+    return `http://gis.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=${this.model.bbl}`;
   }
 
   get zoningMapLink() {

--- a/tests/integration/components/layer-record-views/tax-lot-test.js
+++ b/tests/integration/components/layer-record-views/tax-lot-test.js
@@ -83,7 +83,7 @@ module(
 
       assert.equal(
         find('[data-test-tax-map-link]').getAttribute('href'),
-        'http://maps.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=1000477501'
+        'http://gis.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=1000477501'
       );
     });
 


### PR DESCRIPTION
## Description

This PR updates the digital tax map link from `http://maps.nyc.gov/taxmap/map.htm` to `http://gis.nyc.gov/taxmap/map.htm`
in an effort to avoid a 400 on redirect on Chrome browser when redirected to the DOF hosted tax maps


## Tickets
Closes #1155  
