### PR TITLE
1159 Updated ZOLA DTM link 

### DIFF
--- a/app/models/map-features/lot.js
+++ b/app/models/map-features/lot.js
@@ -543,7 +543,7 @@ export default class LotFragment extends MF.Fragment {
 
     @computed('bbl')
     get digitalTaxMapLink() {
-      return `http://maps.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=${this.bbl}`;
+      return `http://gis.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=${this.bbl}`;
     }
 
     @computed('zonemap')

--- a/tests/unit/models/lot-test.js
+++ b/tests/unit/models/lot-test.js
@@ -62,7 +62,7 @@ module('Unit | Model | lot', function(hooks) {
     const model = await this.owner.lookup('service:store')
       .findRecord('lot', 1007650065);
 
-    assert.equal(model.properties.digitalTaxMapLink, 'http://maps.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=1007650065');
+    assert.equal(model.properties.digitalTaxMapLink, 'http://gis.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=1007650065');
   });
 
   test('it generates correct links: Zoning Map', async function(assert) {


### PR DESCRIPTION
## Description

This PR updates the digital tax map link from `http://maps.nyc.gov/taxmap/map.htm` to `http://gis.nyc.gov/taxmap/map.htm`



## Tickets
Partially Closes #1155  
 - #### TO DO: 
    [x] - Merge [PR#1157 ](https://github.com/NYCPlanning/labs-zola/pull/1157) into develop to sync the changes
