### PR TITLE
Keep derive EmberArray proxy instead of degrading

### DIFF
--- a/app/routes/data.js
+++ b/app/routes/data.js
@@ -5,6 +5,6 @@ export default Route.extend({
   store: service(),
   model() {
     const sources = this.store.peekAll('source');
-    return sources.toArray().uniqBy('meta.description');
+    return sources.uniqBy('meta.description');
   },
 });


### PR DESCRIPTION
Fixes bug in /data route where attempt was made to call `.uniqBy` on a plain array.

Originally, we were "degrading" the derived EmberArray to a plain array (`.toArray()`). This used to work because Ember prototype extensions were still a thing. But those are no more.

Originally .toArray may have been used by force of habit or some vestigial reason. 

This change removes the .toArray call and keeps the derived EmberArray proxy which includes the .uniqBy method.