### PR TITLE
Update tax lot panel to point to new DOF Property Information Portal

### DIFF
--- a/app/components/layer-record-views/tax-lot.js
+++ b/app/components/layer-record-views/tax-lot.js
@@ -441,7 +441,7 @@ export default class TaxLotRecordComponent extends LayerRecordComponent {
   }
 
   get digitalTaxMapLink() {
-    return `http://gis.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=${this.model.bbl}`;
+    return `https://propertyinformationportal.nyc.gov/parcels/parcel/${this.model.bbl}`;
   }
 
   get zoningMapLink() {

--- a/tests/integration/components/layer-record-views/tax-lot-test.js
+++ b/tests/integration/components/layer-record-views/tax-lot-test.js
@@ -83,7 +83,7 @@ module(
 
       assert.equal(
         find('[data-test-tax-map-link]').getAttribute('href'),
-        'http://gis.nyc.gov/taxmap/map.htm?searchType=BblSearch&featureTypeName=EVERY_BBL&featureName=1000477501'
+        'https://propertyinformationportal.nyc.gov/parcels/parcel/1000477501'
       );
     });
 


### PR DESCRIPTION
Updates the Digital Tax Map link to point to DOF's new Property Information Portal and pass the BBL correctly.