### PR TITLE
Update PIP link for condos

### DIFF
--- a/app/components/layer-record-views/tax-lot.js
+++ b/app/components/layer-record-views/tax-lot.js
@@ -441,7 +441,7 @@ export default class TaxLotRecordComponent extends LayerRecordComponent {
   }
 
   get digitalTaxMapLink() {
-    return `https://propertyinformationportal.nyc.gov/parcels/parcel/${this.model.bbl}`;
+    return `https://propertyinformationportal.nyc.gov/parcels/${this.model.condono ? 'condo' : 'parcel'}/${this.model.bbl}`;
   }
 
   get zoningMapLink() {


### PR DESCRIPTION
Update the link to PIP so correctly link to the pages for condo lots.