### PR TITLE
Dh4 toggle all layers off

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -87,6 +87,8 @@ export default class ApplicationController extends Controller.extend(
 
   @service mainMap;
 
+  @service metrics;
+
   // this action extracts query-param-friendly state of layer groups
   // for various paramable layers
   @action
@@ -112,6 +114,18 @@ export default class ApplicationController extends Controller.extend(
       .filter(({ visible }) => visible)
       .forEach((model) => this.toggleLayerVisibilityToFalse(model));
     this.handleLayerGroupChange();
+
+    gtag('event', 'search', {
+      event_category: 'Toggle Layer',
+      event_action: 'Toggle All Layers Off',
+    });
+
+    // GA
+    this.metrics.trackEvent('MatomoTagManager', {
+      category: 'Toggle Layer',
+      action: 'Toggle All Layers Off',
+      name: 'Toggle All Layers Off',
+    });
   }
 
   @action

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { assign } from '@ember/polyfills';
 import { computed, action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import QueryParams from '@nycplanning/ember-parachute';
 import config from 'labs-zola/config/environment';
@@ -89,6 +90,8 @@ export default class ApplicationController extends Controller.extend(
 
   @service metrics;
 
+  @tracked layerGroupsStorage;
+
   // this action extracts query-param-friendly state of layer groups
   // for various paramable layers
   @action
@@ -100,6 +103,7 @@ export default class ApplicationController extends Controller.extend(
       .sort();
 
     this.set('layerGroups', visibleLayerGroups);
+    this.set('layerGroupsStorage', null);
   }
 
   @action
@@ -110,10 +114,18 @@ export default class ApplicationController extends Controller.extend(
 
   @action
   setAllLayerVisibilityToFalse() {
+    // save them so we can be able to reset them
+    const tempStorage = this.model.layerGroups
+      .filter(({ visible }) => visible)
+      .map(({ id }) => id)
+      .sort();
+
     this.model.layerGroups
       .filter(({ visible }) => visible)
       .forEach((model) => this.toggleLayerVisibilityToFalse(model));
     this.handleLayerGroupChange();
+
+    this.set('layerGroupsStorage', tempStorage);
 
     gtag('event', 'search', {
       event_category: 'Toggle Layer',
@@ -129,8 +141,43 @@ export default class ApplicationController extends Controller.extend(
   }
 
   @action
+  undoSetAllLayerVisibilityToFalse() {
+    this.model.layerGroups.forEach((lg) => {
+      if (this.layerGroupsStorage.includes(lg.id)) {
+        lg.set('visible', true);
+      }
+    });
+
+    this.set('layerGroupsStorage', null);
+    this.handleLayerGroupChange();
+
+    gtag('event', 'search', {
+      event_category: 'Toggle Layer',
+      event_action: 'Undo Toggle All Layers Off',
+    });
+
+    // GA
+    this.metrics.trackEvent('MatomoTagManager', {
+      category: 'Toggle Layer',
+      action: 'Undo Toggle All Layers Off',
+      name: 'Undo Toggle All Layers Off',
+    });
+  }
+
+  @action
   toggleLayerVisibilityToFalse(layer) {
     layer.visible = false;
+  }
+
+  @computed('layerGroupsStorage', 'model.layerGroups')
+  get showToggleLayersBackOn() {
+    if (
+      this.model.layerGroups.filter(({ visible }) => visible).length === 0 &&
+      this.layerGroupsStorage
+    ) {
+      return true;
+    }
+    return false;
   }
 
   @computed('queryParamsState')

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -106,6 +106,19 @@ export default class ApplicationController extends Controller.extend(
     this.handleLayerGroupChange();
   }
 
+  @action
+  setAllLayerVisibilityToFalse() {
+    this.model.layerGroups
+      .filter(({ visible }) => visible)
+      .forEach((model) => this.toggleLayerVisibilityToFalse(model));
+    this.handleLayerGroupChange();
+  }
+
+  @action
+  toggleLayerVisibilityToFalse(layer) {
+    layer.visible = false;
+  }
+
   @computed('queryParamsState')
   get isDefault() {
     const state = this.queryParamsState || {};

--- a/app/styles/modules/_m-layer-palette.scss
+++ b/app/styles/modules/_m-layer-palette.scss
@@ -135,7 +135,7 @@ $layer-palette-hover-color: rgba($dark-gray,0.08);
 // "Toggle All Map Layers Off" button
 // --------------------------------------------------
 .no-layers-button {
-  margin: $layer-palette-padding*0 $layer-palette-padding*2 $layer-palette-padding*3 $layer-palette-padding*2;
+  margin: $layer-palette-padding*3 $layer-palette-padding*2 $layer-palette-padding*2 $layer-palette-padding*2;
   width: calc(100% - #{$layer-palette-padding*4});
 }
 

--- a/app/styles/modules/_m-layer-palette.scss
+++ b/app/styles/modules/_m-layer-palette.scss
@@ -131,6 +131,13 @@ $layer-palette-hover-color: rgba($dark-gray,0.08);
   width: calc(100% - #{$layer-palette-padding*4});
 }
 
+//
+// "Toggle All Map Layers Off" button
+// --------------------------------------------------
+.no-layers-button {
+  margin: $layer-palette-padding*0 $layer-palette-padding*2 $layer-palette-padding*3 $layer-palette-padding*2;
+  width: calc(100% - #{$layer-palette-padding*4});
+}
 
 //
 // Indeterminate hider (hides element alongside unchecked checkbox)

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -30,6 +30,7 @@
           @layerGroups={{this.model.layerGroupsObject}}
           @isDefault={{this.isDefault}}
           @resetQueryParams={{action this.setModelsToDefault}}
+          @setAllLayerVisibilityToFalse={{action this.setAllLayerVisibilityToFalse}}
           @handleLayerGroupChange={{action this.handleLayerGroupChange}}
         />
       </div>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -31,7 +31,9 @@
           @isDefault={{this.isDefault}}
           @resetQueryParams={{action this.setModelsToDefault}}
           @setAllLayerVisibilityToFalse={{action this.setAllLayerVisibilityToFalse}}
+          @undoSetAllLayerVisibilityToFalse={{action this.undoSetAllLayerVisibilityToFalse}}
           @handleLayerGroupChange={{action this.handleLayerGroupChange}}
+          @showToggleLayersBackOn={{this.showToggleLayersBackOn}}
         />
       </div>
     </div>

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -331,5 +331,12 @@
     <FaIcon @icon="undo" />
     Reset Map Layers
   </a>
+  <a
+    class="button gray small no-layers-button hide-for-print"
+    onclick={{action this.setAllLayerVisibilityToFalse}}
+    data-test-reset-query-params="true">
+    <FaIcon @icon="circle-xmark" @prefix="far" />
+    Toggle All Map Layers Off
+  </a>
 </div>
 {{yield}}

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -14,7 +14,7 @@
       class="button gray small no-layers-button hide-for-print"
       onclick={{action this.undoSetAllLayerVisibilityToFalse}}
       data-test-reset-query-params="true">
-      <FaIcon @icon="circle-xmark" @prefix="far" />
+      <FaIcon @icon="undo" />
       Toggle Layers Back On
     </a>
   {{else}}

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -9,6 +9,13 @@
   {{/if}}
 </button>
 <div id="layers-menu" class="{{if this.closed "show-for-medium"}}">
+  <a
+    class="button gray small no-layers-button hide-for-print"
+    onclick={{action this.setAllLayerVisibilityToFalse}}
+    data-test-reset-query-params="true">
+    <FaIcon @icon="circle-xmark" @prefix="far" />
+    Toggle All Map Layers Off
+  </a>
   <LabsUiOverrides::LayerGroupsContainer
     @handleToggle={{action this.handleLayerGroupToggle}}
     @title="Zoning and Land Use" as |container|
@@ -330,13 +337,6 @@
     data-test-reset-query-params="true">
     <FaIcon @icon="undo" />
     Reset Map Layers
-  </a>
-  <a
-    class="button gray small no-layers-button hide-for-print"
-    onclick={{action this.setAllLayerVisibilityToFalse}}
-    data-test-reset-query-params="true">
-    <FaIcon @icon="circle-xmark" @prefix="far" />
-    Toggle All Map Layers Off
   </a>
 </div>
 {{yield}}

--- a/app/templates/components/layer-palette.hbs
+++ b/app/templates/components/layer-palette.hbs
@@ -9,13 +9,23 @@
   {{/if}}
 </button>
 <div id="layers-menu" class="{{if this.closed "show-for-medium"}}">
-  <a
-    class="button gray small no-layers-button hide-for-print"
-    onclick={{action this.setAllLayerVisibilityToFalse}}
-    data-test-reset-query-params="true">
-    <FaIcon @icon="circle-xmark" @prefix="far" />
-    Toggle All Map Layers Off
-  </a>
+  {{#if this.showToggleLayersBackOn}}
+    <a
+      class="button gray small no-layers-button hide-for-print"
+      onclick={{action this.undoSetAllLayerVisibilityToFalse}}
+      data-test-reset-query-params="true">
+      <FaIcon @icon="circle-xmark" @prefix="far" />
+      Toggle Layers Back On
+    </a>
+  {{else}}
+    <a
+      class="button gray small no-layers-button hide-for-print"
+      onclick={{action this.setAllLayerVisibilityToFalse}}
+      data-test-reset-query-params="true">
+      <FaIcon @icon="circle-xmark" @prefix="far" />
+      Toggle All Map Layers Off
+    </a>
+  {{/if}}
   <LabsUiOverrides::LayerGroupsContainer
     @handleToggle={{action this.handleLayerGroupToggle}}
     @title="Zoning and Land Use" as |container|
@@ -330,13 +340,5 @@
       </ul>
     </container.layer-group-toggle>
   </LabsUiOverrides::LayerGroupsContainer>
-  <a
-    class="button gray small reset-map-button hide-for-print"
-    disabled={{this.isDefault}}
-    onclick={{action this.resetQueryParams}}
-    data-test-reset-query-params="true">
-    <FaIcon @icon="undo" />
-    Reset Map Layers
-  </a>
 </div>
 {{yield}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -382,6 +382,7 @@ module.exports = function (environment) {
           'circle',
           'dot-circle',
           'square',
+          'circle-xmark',
         ],
         'free-solid-svg-icons': [
           'angle-up',

--- a/config/icons.js
+++ b/config/icons.js
@@ -5,6 +5,7 @@ module.exports = function () {
       'circle',
       'dot-circle',
       'square',
+      'circle-xmark',
     ],
     'free-solid-svg-icons': [
       'angle-up',


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This removes the "Reset Map Layers" button. It adds a similarly formatted button to the top of the menu on the left side which turns off all map layers. When pressed, until another layer is turned on, the button changes to allow the user to revert back to the previous set of layers.

<img width="582" alt="image" src="https://github.com/NYCPlanning/labs-zola/assets/61206501/bfd56693-0545-45fb-9c1d-a6afe20ae2ee">

Completes #1189 
