### PR TITLE
Add Search History - Revised

### DIFF
--- a/app/templates/components/map-resource-search.hbs
+++ b/app/templates/components/map-resource-search.hbs
@@ -1,5 +1,5 @@
 <div class="search-container hide-for-print">
-  <LabsSearch
+  <ZolaSearch
     data-test-search="resource"
     @onSelect={{action "handleSearchSelect"}}
     @typeTitleLookup={{this.resourceTitleLookup}}


### PR DESCRIPTION
This PR updates @nycplanning/ember to use the branch with the newly created Zola search history functionality
<img width="364" alt="image" src="https://github.com/NYCPlanning/labs-zola/assets/61206501/8a1c474b-b89b-42f2-ae14-90c6f7ebd369">

This is the revised branch, which uses the newly created component from [this pull request](https://github.com/NYCPlanning/ose-ember-addons/pull/13).  Once a new version of that repo has been published we should updated package.json in this branch to ensure usage of a branch with the new component.

To pre-populate your search history, paste the below into the console.
```
window.localStorage["search-history"] = '[{"label":"CHRYSLER BUILDING, New York, NY, USA","bbl":"1012970023","geometry":{"type":"Point","coordinates":[-73.97533,40.751639]},"type":"lot","id":0,"typeTitle":"Search History"},{"label":"EMPIRE STATE BUILDING, New York, NY, USA","bbl":"1008350041","geometry":{"type":"Point","coordinates":[-73.985654,40.748433]},"type":"lot","id":0,"typeTitle":"Search History"},{"label":"STATUE OF LIBERTY, New York, NY, USA","bbl":"1000010101","geometry":{"type":"Point","coordinates":[-74.044535,40.689232]},"type":"lot","id":0,"typeTitle":"Search History"},{"label":"YANKEE STADIUM, Bronx, NY, USA","bbl":"2024930001","geometry":{"type":"Point","coordinates":[-73.926473,40.828812]},"type":"lot","id":0,"typeTitle":"Search History"},{"label":"CITI FIELD, Flushing Meadows, NY, USA","bbl":"4017870020","geometry":{"type":"Point","coordinates":[-73.844636,40.757003]},"type":"lot","id":0,"typeTitle":"Search History"},{"label":"120 BROADWAY, New York, NY, USA","bbl":"1000477501","geometry":{"type":"Point","coordinates":[-74.01054,40.708225]},"type":"lot","id":0,"typeTitle":"Search History"}]'
```

Closes #1191 