### PR TITLE
Update default selected aerial layer

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -70,7 +70,7 @@ export const mapQueryParams = new QueryParams(
     },
 
     'aerial-year': {
-      defaultValue: 'aerials-2016',
+      defaultValue: 'aerials-2022',
     },
 
     // TODO: After merge of params refactor, update print service based on this param.


### PR DESCRIPTION
Closes #1198.

- Updates default selected aerial layer to be aerials-2022

![Screen Shot 2024-04-11 at 11 28 46 AM](https://github.com/NYCPlanning/labs-zola/assets/43344288/712bbb64-21fb-4e02-86a5-9052c062a04e)
