### PR TITLE
Use heroku layers API URL

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,4 @@
-const HOST = process.env.API_HOST || 'https://labs-layers-api.herokuapp.com/';
+const HOST = process.env.API_HOST || 'https://labs-layers-api.herokuapp.com';
 const CARTO_USER = process.env.CARTO_USER || 'planninglabs';
 
 module.exports = function (environment) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,4 @@
-const HOST = process.env.API_HOST || 'https://layers-api.planninglabs.nyc';
+const HOST = process.env.API_HOST || 'https://labs-layers-api.herokuapp.com/';
 const CARTO_USER = process.env.CARTO_USER || 'planninglabs';
 
 module.exports = function (environment) {


### PR DESCRIPTION
Switching to using heroku layers api Prod URL directly due to issues with planninglabs.nyc domains
