### PR TITLE
Update Matomo to use cloud hosting instead of self-hosted.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,7 +13,7 @@
       _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
       (function() {
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src='https://matomo.planninglabs.nyc/js/container_9G7PP94F.js'; s.parentNode.insertBefore(g,s);
+        g.async=true; g.src='https://cdn.matomo.cloud/nycplanning.matomo.cloud/container_mSBprcFI.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
     <!-- End Matomo Tag Manager -->

--- a/config/environment.js
+++ b/config/environment.js
@@ -8,8 +8,8 @@ module.exports = function (environment) {
         name: 'MatomoTagManager',
         environments: ['development', 'production', 'test'],
         config: {
-          matomoUrl: 'matomo.planninglabs.nyc',
-          containerId: '9G7PP94F',
+          matomoUrl: 'nycplanning.matomo.cloud',
+          containerId: 'mSBprcFI',
         },
       },
     ],


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR update Matomo to use cloud hosting instead of self-hosted.

Part of [ae-private#36](https://github.com/NYCPlanning/ae-private/issues/36)
