### PR TITLE
Add exceptions for street-centerlines layer group to logic for hiding all layers

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -135,7 +135,11 @@ export default class ApplicationController extends Controller.extend(
 
     this.model.layerGroups
       .filter(({ visible }) => visible)
-      .forEach((model) => this.toggleLayerVisibilityToFalse(model));
+      .forEach(
+        (model) =>
+          model.id !== 'street-centerlines' &&
+          this.toggleLayerVisibilityToFalse(model)
+      );
     this.handleLayerGroupChange();
 
     this.set('layerGroupsStorage', tempStorage);
@@ -185,7 +189,9 @@ export default class ApplicationController extends Controller.extend(
   @computed('layerGroupsStorage', 'model.layerGroups')
   get showToggleLayersBackOn() {
     if (
-      this.model.layerGroups.filter(({ visible }) => visible).length === 0 &&
+      this.model.layerGroups.filter(
+        ({ id, visible }) => visible && id !== 'street-centerlines'
+      ).length === 0 &&
       this.layerGroupsStorage
     ) {
       return true;


### PR DESCRIPTION
This PR fixes an apparent bug in the "Toggle All Map Layers Off" functionality introduced in #1181 that was reported in helpscout ticket 3984. Toggling off all layer groups hides the `street-centerlines` layer group which is what renders the street names and widths
<img width="152" alt="image" src="https://github.com/user-attachments/assets/aca60d54-536c-4202-bb09-1e402a363439">
Because there is no corresponding toggle for that layer in the layer palette, the only way the user can get them back is by clicking the "Toggle All Layers Back On" button. This code filters out that layer group so that it isn't hidden. Ideally we wouldn't hard code layer group ids into application code like this but, as things stand, there doesn't seem to be an easy way to distinguish layer groups with toggles in the layer palette from those without. 