### PR TITLE
Add record for East Tremont Corridor special district to environment.js

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -83,6 +83,7 @@ module.exports = function (environment) {
       ['Special Hunts Point District', ['HP', 'bronx']],
       ['Special Harlem River Waterfront District', ['HRW', 'bronx']],
       ['Special Jerome Corridor District', ['J', 'bronx']],
+      ['Special Eastchester – East Tremont Corridor', ['ETC', 'bronx']],
       ['Special Natural Area District-1', ['natural_area', 'bronx']],
       ['Special Natural Area District-2', ['natural_area', 'bronx']],
       ['Special Natural Area District-3', ['natural_area', 'bronx']],


### PR DESCRIPTION
This PR adds a record to environment.js for the new [Bronx East Tremont Corridor special district](https://www.nyc.gov/site/planning/zoning/districts-tools/special-purpose-districts-bronx.page#ETC).