### PR TITLE
Layer palette unreachable on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /yarn-error.log
 development.env
 **/.DS_Store
+/.vscode
 
 # ember-try
 /.node_modules.ember-try/

--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -103,8 +103,6 @@ body {
 }
 
 body.index {
-  overflow: hidden;
-
   @include breakpoint(small only) {
     .map-grid,
     .map-container {


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/labs-zola/issues/1228

To replicate the bug / test out the PR:

1. Open ZoLa / localhost:4200
2. Switch to mobile view if on desktop
3. Close the new features pop up
4. Click on 'Edit Map Layers'
5. Scroll down and exit the "Welcome to..." panel 

Now you should not be able to scroll back up or down. This PR should fix that.*

* The caveat is, the `overflow` property I removed was initially in place to fix a [mobile scrolling issue](https://github.com/NYCPlanning/labs-zola/pull/401/commits/27af75417b9d907e78a9179f84392f493662025d). So it may be that there are some knock-on effects 