### PR TITLE
Change local storage variable for showing new features modal

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -207,7 +207,7 @@ export default class ApplicationController extends Controller.extend(
   }
 
   @tracked
-  openModal = !window.localStorage.hideMessage;
+  openModal = !window.localStorage.hideMessageZoningIndexMap;
 
   @tracked
   dontShowModalAgain = false;
@@ -215,7 +215,7 @@ export default class ApplicationController extends Controller.extend(
   @action toggleModal() {
     this.openModal = !this.openModal;
     if (this.dontShowModalAgain) {
-      window.localStorage.hideMessage = true;
+      window.localStorage.hideMessageZoningIndexMap = true;
     }
   }
 


### PR DESCRIPTION
## Summary
This PR changes the local storage variable name used by the new features modal so that users who previously dismissed it see it again, including the new slide for the Zoning Map Index layer.