### PR TITLE
Update intersecting layer template to hide ZFA layer behind feature flag

### DIFF
--- a/app/components/layer-record-views/tax-lot/intersecting-layers-views.js
+++ b/app/components/layer-record-views/tax-lot/intersecting-layers-views.js
@@ -1,7 +1,12 @@
 import Component from '@ember/component';
+import { tracked } from '@glimmer/tracking';
+import config from 'labs-zola/config/environment';
 
 export default class IntersectingLayersViews extends Component {
   model = null;
+
+  @tracked
+  showZFALayer = config.featureFlagShowZFALayer;
 
   tables = [
     'inclusionary_housing',

--- a/app/templates/components/layer-record-views/tax-lot/intersecting-layers-views.hbs
+++ b/app/templates/components/layer-record-views/tax-lot/intersecting-layers-views.hbs
@@ -155,7 +155,7 @@
       </a>
     </li>
   {{/if}}
-  {{#if layers.mta_rail_station_50ft_buffers}}
+  {{#if (and layers.mta_rail_station_50ft_buffers this.showZFALayer)}}
     <li>
       <a
         href="https://www.nyc.gov/content/planning/pages/our-work/plans/citywide/elevate-transit-zoning-accessibility"


### PR DESCRIPTION
## Summary

This PR addresses an issue where the ZFA intersecting layer for tax lots wasn't hidden behind the feature flag and thus would have gone out in the upcoming release for Zoning Map Index.