### PR TITLE
1269 Update default ortho layer to 2024

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -71,7 +71,7 @@ export const mapQueryParams = new QueryParams(
     },
 
     'aerial-year': {
-      defaultValue: 'aerials-2022',
+      defaultValue: 'aerials-2024',
     },
 
     // TODO: After merge of params refactor, update print service based on this param.


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

# Acceptance criteria

- [ ] Update the default ortho layer shown to from 2022 to 2024. Example from last time we updated this can be found [here](https://github.com/NYCPlanning/labs-zola/pull/1200).

Closes #1269

Note: although I have made the requested changes, they were unnecessary; the site appears to disregard this value and show 2024 by default, the changes will go into effect as soon as the changes to Layers API are in production.