### PR TITLE
1275 Update map amendment link locations

### DIFF
--- a/app/templates/components/layer-record-views/zoning-map-amendment.hbs
+++ b/app/templates/components/layer-record-views/zoning-map-amendment.hbs
@@ -47,7 +47,7 @@
   <span class="datum">
     <a
       target="_blank"
-      href="http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/sketchmaps/skz{{this.model.ulurpno}}.pdf" rel="noopener noreferrer"
+      href="https://nyc3.digitaloceanspaces.com/zoningmap/skz{{this.model.ulurpno}}.pdf" rel="noopener noreferrer"
     >
       {{this.model.ulurpno}}
       <small>


### PR DESCRIPTION
<!-- Be sure to merge the latest from `develop` and make sure your tests pass -->

This PR updates the sketch map link used for Zoning Map Amendments and Pending Zoning Map Amendments to start with `https://nyc3.digitaloceanspaces.com/zoningmap/skz` instead of `http://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-maps/sketchmaps/skz`.

Closes #1275