### PR TITLE
Add aam to environment.js

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -187,6 +187,7 @@ module.exports = function (environment) {
       ['Special 125th Street District', ['125', 'manhattan']],
       ['Special Enhanced Commercial District', ['EC', ' brooklyn']],
       ['Special Flushing Waterfront District', ['FW', 'queens']],
+      ['Special Atlantic Avenue Mixed Use District (AAM)', ['AAM', 'brooklyn']],
     ],
 
     zoningDistrictOptionSets: [


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/labs-zola/issues/1288

Fixes the "Learn more" link for Special Atlantic Avenue Mixed Use District by adding it explicitly so that the url can be generated from the tag "AAM"