### PR TITLE
Update name of special purpose district

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -159,7 +159,7 @@ module.exports = function (environment) {
       ['Special Little Italy District', ['LI', 'manhattan']],
       ['Special Lower Manhattan District', ['LM', 'manhattan']],
       ['Special Midtown District', ['MID', 'manhattan']],
-      ['Special Midtown South Mixed Use District ', ['MSX', 'manhattan']],
+      ['Special Midtown South Mixed-Use District', ['MSX', 'manhattan']],
       ['Special Manhattanville Mixed Use District', ['MMU', 'manhattan']],
       ['Special Madison Avenue Preservation District', ['MP', 'manhattan']],
       ['Special Park Improvement District', ['PI', 'manhattan']],


### PR DESCRIPTION
#### Description
updated spelling of the special purpose district name from 
`'Special Midtown South Mixed Use District '` to 
`'Special Midtown South Mixed-Use District'`
with no whitespace and with hypen 

<img width="764" height="413" alt="Screenshot 2026-07-01 at 3 53 50 PM" src="https://github.com/user-attachments/assets/acbcffac-0071-4a13-b49c-9dcc7de2aa6f" />

#### Tickets
Closes #1317

